### PR TITLE
Support for no founders/no owners

### DIFF
--- a/src/calc/payment_calculator.py
+++ b/src/calc/payment_calculator.py
@@ -10,7 +10,6 @@ class PaymentCalculator:
         self.fee_calc = service_fee_calculator
         self.reward_list = reward_list
         self.founders_map = founders_map
-        self.total_service_fee = 0
 
     #
     # calculation details
@@ -46,21 +45,34 @@ class PaymentCalculator:
             delegators_total_fee = delegators_total_fee + fee
 
         # 2- calculate deposit owners payments. They share the remaining rewards according to their ratio (check config)
-        owners_total_payment = 0
+        owners_total_pymnt = 0
         owners_total_reward = self.total_rewards - (delegators_total_pymnt + delegators_total_fee)
-        for address, ratio in self.owners_map.items():
-            owner_pymnt_amnt = floorf(ratio * owners_total_reward, 3)
-            owners_total_payment = owners_total_payment + owner_pymnt_amnt
-
-            pymnts.append(PaymentRecord.OwnerInstance(self.cycle, address, ratio, owner_pymnt_amnt, owner_pymnt_amnt))
+        no_owners = True
+        
+        # Skip if no owners defined
+        if len(self.owners_map) > 0:
+            no_owners = False
+            for address, ratio in self.owners_map.items():
+                owner_pymnt_amnt = floorf(ratio * owners_total_reward, 3)
+                owners_total_pymnt = owners_total_pymnt + owner_pymnt_amnt
+                pymnts.append(PaymentRecord.OwnerInstance(self.cycle, address, ratio, owner_pymnt_amnt, owner_pymnt_amnt))
 
         # move remaining rewards to service fee bucket
-        self.total_service_fee = self.total_rewards - delegators_total_pymnt - owners_total_payment
-
         # 3- service fee is shared among founders according to founders_map ratios
-        for address, ratio in self.founders_map.items():
-            pymnt_amnt = floorf(ratio * self.total_service_fee, 6)
-            pymnts.append(PaymentRecord.FounderInstance(self.cycle, address, ratio, pymnt_amnt))
+        founders_total_pymnt = 0
+        founders_total_reward = self.total_rewards - delegators_total_pymnt - owners_total_pymnt
+        no_founders = True
+
+        # If no owners paid, must include their would-be reward in this calculation
+        if no_owners:
+            founders_total_reward = founders_total_reward - owners_total_reward
+        
+        # Skip if no founders defined
+        if len(self.founders_map) > 0:
+            no_founders = False
+            for address, ratio in self.founders_map.items():
+                founder_pymnt_amnt = floorf(ratio * founders_total_reward, 6)
+                pymnts.append(PaymentRecord.FounderInstance(self.cycle, address, ratio, founder_pymnt_amnt))
 
         ###
         # sanity check
@@ -69,13 +81,20 @@ class PaymentCalculator:
         for payment_log in pymnts:
             total_sum = total_sum + payment_log.payment
 
+        # if no owners/no founders, add that would-be amount to total_sum
+        # the baker will keep (owners_total_reward + founders_total_reward) automatically when unfrozen
+        if no_owners:
+            total_sum = total_sum + owners_total_reward
+        if no_founders:
+            total_sum = total_sum + founders_total_reward
+
         # if there is a minor difference due to floor function; it is added to last payment
         if self.total_rewards - total_sum > 1e-6:
-            last_payment_log = pymnts[-1]  # last payment, probably one of the founders
-            last_payment_log.payment = last_payment_log.payment + (self.total_rewards - total_sum)
+            last_pymnt_log = pymnts[-1]  # last payment, probably one of the founders
+            last_pymnt_log.payment = last_pymnt_log.payment + (self.total_rewards - total_sum)
 
         # this must never return true
         if abs(total_sum - self.total_rewards) > 5e-6:
-            raise Exception("Calculated reward {} is not equal total reward {}".format(total_sum, self.total_rewards))
+            raise Exception("Calculated reward {} is not equal to total reward {}".format(total_sum, self.total_rewards))
 
         return pymnts

--- a/src/main.py
+++ b/src/main.py
@@ -286,8 +286,9 @@ class ProducerThread(threading.Thread):
 
 # all shares in the map must sum up to 1
 def validate_map_share_sum(share_map, map_name):
-    if abs(1 - sum(share_map.values()) > 1e-4):  # a zero check actually
-        raise Exception("Map '{}' shares does not sum up to 1!".format(map_name))
+    if len(share_map) > 0:
+        if abs(1 - sum(share_map.values()) > 1e-4):  # a zero check actually
+            raise Exception("Map '{}' shares does not sum up to 1!".format(map_name))
 
 
 def main(config):


### PR DESCRIPTION
Simple bakers do not have founders or owners. This PR removes the requirement to configure founders and owners as yourself, which wastes 2 transactions sending XTZ to yourself.

Resolves #17 