### PR TITLE
Fix spelling

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -392,7 +392,7 @@ if __name__ == '__main__':
                         action="store_true")
     parser.add_argument("-E", "--executable_dirs",
                         help="Comma separated list of directories to search for client executable. Prefer single "
-                             "location when setting client directory. If -d is set, poin to location where docker "
+                             "location when setting client directory. If -d is set, point to location where docker "
                              "script is found. Default value is given for minimum configuration effort.",
                         default='~/,~/tezos')
     parser.add_argument("-d", "--docker",


### PR DESCRIPTION
Spelling error for the Docker config.

Speaking of which, could you elaborate on how this works? By "point to location where docker script is found", does that mean the Docker executable (eg. `/usr/bin/docker`), or `mainnet.sh`, part of the Tezos Docker distribution?
