### PR TITLE
Get network constants from a node service and remove dependency on tzscan (resolves #7, #63 and #64)

### DIFF
--- a/src/NetworkConfiguration.py
+++ b/src/NetworkConfiguration.py
@@ -1,6 +1,61 @@
-# todo: replace with rpc client rpc get /chains/main/blocks/head/context/constants
-network_config_map = {
-    'MAINNET': {'NAME': 'MAINNET', 'NB_FREEZE_CYCLE': 5, 'BLOCK_TIME_IN_SEC': 60, 'BLOCKS_PER_CYCLE': 4096},
-    'ALPHANET': {'NAME': 'ALPHANET', 'NB_FREEZE_CYCLE': 2, 'BLOCK_TIME_IN_SEC': 30, 'BLOCKS_PER_CYCLE': 2048},
-    'ZERONET': {'NAME': 'ZERONET', 'NB_FREEZE_CYCLE': 5, 'BLOCK_TIME_IN_SEC': 20, 'BLOCKS_PER_CYCLE': 128},
+from log_config import main_logger
+from util.rpc_utils import parse_json_response
+import requests
+
+logger = main_logger
+
+default_network_config_map = {
+    'MAINNET': {'NAME': 'MAINNET', 'NB_FREEZE_CYCLE': 5, 'BLOCK_TIME_IN_SEC': 60, 'BLOCKS_PER_CYCLE': 4096, 'BLOCKS_PER_ROLL_SNAPSHOT':256},
+    'ALPHANET': {'NAME': 'ALPHANET', 'NB_FREEZE_CYCLE': 3, 'BLOCK_TIME_IN_SEC': 30, 'BLOCKS_PER_CYCLE': 2048, 'BLOCKS_PER_ROLL_SNAPSHOT':256},
+    'ZERONET': {'NAME': 'ZERONET', 'NB_FREEZE_CYCLE': 5, 'BLOCK_TIME_IN_SEC': 20, 'BLOCKS_PER_CYCLE': 128, 'BLOCKS_PER_ROLL_SNAPSHOT':8},
 }
+
+CONSTANTS_COMM = "rpc get http://{}/chains/main/blocks/head/context/constants"
+URL = "https://{}.tzbeta.net/chains/main/blocks/head/context/constants"
+url_prefix = {"MAINNET" : "rpc", "ALPHANET" : "rpcalpha", "ZERONET" : "rpczero"}
+
+def init_network_config(network_name, config_client_manager, node_addr):
+    network_config_map = {}    
+    try:
+        network_config_map[network_name] = get_network_config_from_local_node(config_client_manager, node_addr)
+        network_config_map[network_name]['NAME'] = network_name
+        logger.info("Network configuration constants successfully loaded from a local node.")
+        return network_config_map
+    except:
+        logger.info("Failed to get network configuration constants from a local node.")
+    
+    try:
+        network_config_map[network_name] = get_network_config_from_public_node(network_name)
+        network_config_map[network_name]['NAME'] = network_name
+        logger.info("Network configuration constants successfully loaded from a public node.")
+        return network_config_map
+    except:
+        logger.info("Failed to get network configuration constants from a public node.")
+    
+    logger.info("Default network configuration constants will be used.")
+    return default_network_config_map
+
+
+
+def get_network_config_from_local_node(config_client_manager, node_addr):
+    request_constants = CONSTANTS_COMM.format(node_addr)
+    response_constants = config_client_manager.send_request(request_constants)
+    constants = parse_json_response(response_constants)
+    network_config_map = parse_constants(constants)
+    return network_config_map
+
+
+def get_network_config_from_public_node(network_name):
+    url = URL.format(url_prefix[network_name])
+    response_constants = requests.get(url)
+    constants = response_constants.json()
+    network_config_map = parse_constants(constants)
+    return network_config_map
+    
+def parse_constants(constants):
+    network_config_map = {}
+    network_config_map['NB_FREEZE_CYCLE'] = int(constants['preserved_cycles'])    
+    network_config_map['BLOCK_TIME_IN_SEC'] = int(constants['time_between_blocks'][0])
+    network_config_map['BLOCKS_PER_CYCLE'] = int(constants['blocks_per_cycle'])
+    network_config_map['BLOCKS_PER_ROLL_SNAPSHOT'] = int(constants['blocks_per_roll_snapshot'])
+    return network_config_map

--- a/src/main.py
+++ b/src/main.py
@@ -7,9 +7,10 @@ import sys
 import time
 
 from Constants import RunMode
-from NetworkConfiguration import network_config_map
+from NetworkConfiguration import init_network_config
 from calc.service_fee_calculator import ServiceFeeCalculator
 from cli.wallet_client_manager import WalletClientManager
+from cli.simple_client_manager import SimpleClientManager
 from config.config_parser import ConfigParser
 from config.yaml_baking_conf_parser import BakingYamlConfParser
 from config.yaml_conf_parser import YamlConfParser
@@ -65,16 +66,20 @@ def main(args):
     if 'addresses_by_pkh' in master_cfg:
         addresses_by_pkh = master_cfg['addresses_by_pkh']
 
-    # 3-
 
-    # 4- get client path
-    network_config = network_config_map[args.network]
+    # 3- get client path
+    
     client_path = get_client_path([x.strip() for x in args.executable_dirs.split(',')],
-                                  args.docker, network_config,
+                                  args.docker, args.network,
                                   args.verbose)
 
     logger.debug("Tezos client path is {}".format(client_path))
-
+    
+    # 4. get network config     
+    config_client_manager = SimpleClientManager(client_path)
+    network_config_map = init_network_config(args.network, config_client_manager, args.node_addr)
+    network_config = network_config_map[args.network]
+    
     # 5- load baking configuration file
     config_file_path = get_baking_configuration_file(config_dir)
 

--- a/src/main.py
+++ b/src/main.py
@@ -144,7 +144,8 @@ def main(args):
                         payments_dir=payments_root, calculations_dir=calculations_root, run_mode=RunMode(args.run_mode),
                         service_fee_calc=srvc_fee_calc, release_override=args.release_override,
                         payment_offset=args.payment_offset, baking_cfg=cfg, life_cycle=life_cycle,
-                        payments_queue=payments_queue, dry_run=dry_run, verbose=args.verbose)
+                        payments_queue=payments_queue, dry_run=dry_run, wllt_clnt_mngr=wllt_clnt_mngr, 
+                        node_url=args.node_addr, verbose=args.verbose)
     p.start()
 
     for i in range(NB_CONSUMERS):

--- a/src/pay/payment_producer.py
+++ b/src/pay/payment_producer.py
@@ -45,16 +45,17 @@ class PaymentProducer(threading.Thread):
         self.name = name
 
         rc = RoundingCommand(self.prcnt_scale)
-        
-        self.block_api_tzscan = TzScanBlockApiImpl(network_config)
-        self.reward_api_tzscan = TzScanRewardApiImpl(network_config, self.baking_address)        
-        self.reward_calculator_api_tzscan = TzScanRewardCalculatorApi(self.founders_map, self.min_delegation_amt, self.excluded_delegators_set, rc)
+                
         
         if BOOL_USE_LOCAL_NODE:
-            self.block_api_rpc = RpcBlockApiImpl(network_config, wllt_clnt_mngr, node_url)
-            self.reward_api_rpc = RpcRewardApiImpl(network_config, self.baking_address, wllt_clnt_mngr, node_url)        
-            self.reward_calculator_api_rpc = RpcRewardCalculatorApi(self.founders_map, self.min_delegation_amt, self.excluded_delegators_set, rc)
-        
+            self.block_api = RpcBlockApiImpl(network_config, wllt_clnt_mngr, node_url)
+            self.reward_api = RpcRewardApiImpl(network_config, self.baking_address, wllt_clnt_mngr, node_url)        
+            self.reward_calculator_api = RpcRewardCalculatorApi(self.founders_map, self.min_delegation_amt, self.excluded_delegators_set, rc)
+        else:
+            self.block_api = TzScanBlockApiImpl(network_config)
+            self.reward_api = TzScanRewardApiImpl(network_config, self.baking_address)        
+            self.reward_calculator_api = TzScanRewardCalculatorApi(self.founders_map, self.min_delegation_amt, self.excluded_delegators_set, rc)
+
         self.fee_calc = service_fee_calc
         self.initial_payment_cycle = initial_payment_cycle
         self.nw_config = network_config
@@ -80,12 +81,7 @@ class PaymentProducer(threading.Thread):
 
     def run(self):
         
-        current_cycle_tzscan = self.block_api_tzscan.get_current_cycle()
-        if BOOL_USE_LOCAL_NODE:
-            current_cycle_rpc = self.block_api_rpc.get_current_cycle()
-            current_cycle = min(current_cycle_tzscan, current_cycle_rpc) 
-        else:
-            current_cycle = current_cycle_tzscan     
+        current_cycle = self.block_api.get_current_cycle()
         
         payment_cycle = self.initial_payment_cycle
 
@@ -104,14 +100,8 @@ class PaymentProducer(threading.Thread):
 
             logger.debug("Trying payments for cycle {}".format(payment_cycle))
             
-            current_level_tzscan = self.block_api_tzscan.get_current_level()
-            if BOOL_USE_LOCAL_NODE:
-                current_level_rpc = self.block_api_rpc.get_current_level()
-                current_level = min(current_level_tzscan, current_level_rpc) 
-            else:
-                current_level = current_level_tzscan
-            
-            current_cycle = self.block_api_tzscan.level_to_cycle(current_level)
+            current_level = self.block_api.get_current_level()
+            current_cycle = self.block_api.level_to_cycle(current_level)
 
             # create reports dir
             if self.calculations_dir and not os.path.exists(self.calculations_dir):
@@ -131,19 +121,10 @@ class PaymentProducer(threading.Thread):
                         logger.info("Payment cycle is " + str(payment_cycle))
 
                         # 1- get reward data
-                        reward_data_tzscan = self.reward_api_tzscan.get_rewards_for_cycle_map(payment_cycle, verbose=self.verbose)
-                        
-                        if BOOL_USE_LOCAL_NODE:
-                            reward_data_rpc = self.reward_api_rpc.get_rewards_for_cycle_map(payment_cycle, verbose=self.verbose)
-                            self.__validate_reward_data(reward_data_rpc, reward_data_tzscan)                        
+                        reward_data = self.reward_api.get_rewards_for_cycle_map(payment_cycle, verbose=self.verbose)
                             
                         # 2- make payment calculations from reward data
-                        pymnt_logs_tzscan, total_rewards_tzscan = self.make_payment_calculations(payment_cycle, reward_data_tzscan, self.reward_calculator_api_tzscan)
-                        pymnt_logs_rpc, total_rewards_rpc = None, None                         
-                        if BOOL_USE_LOCAL_NODE:
-                            pymnt_logs_rpc, total_rewards_rpc = self.make_payment_calculations(payment_cycle, reward_data_rpc, self.reward_calculator_api_rpc)
-                        
-                        pymnt_logs, total_rewards = self.__validate_reward_shares(pymnt_logs_rpc, total_rewards_rpc, pymnt_logs_tzscan, total_rewards_tzscan)                       
+                        pymnt_logs, total_rewards = self.make_payment_calculations(payment_cycle, reward_data)
                         
                         # 3- check for past payment evidence for current cycle
                         past_payment_state = check_past_payment(self.payments_root, payment_cycle)
@@ -212,52 +193,6 @@ class PaymentProducer(threading.Thread):
 
         return
     
-    def __validate_reward_data(self, reward_data_rpc, reward_data_tzscan):    
-        if not reward_data_rpc["delegate_staking_balance"] == int(reward_data_tzscan["delegate_staking_balance"]):
-            raise Exception("Delegate staking balance from local node and tzscan are not identical.")
-                
-        if not (reward_data_rpc["delegators_nb"]) == (reward_data_tzscan["delegators_nb"]):
-            raise Exception("Delegators number from local node and tzscan are not identical.")
-        
-        if (reward_data_rpc["delegators_nb"]) == 0:
-            return
-        
-        delegators_balance_tzscan = [ int(reward_data_tzscan["delegators_balance"][i][1]) for i in range(len(reward_data_tzscan["delegators_balance"]))]
-        print(set(list(reward_data_rpc["delegators"].values())))
-        print(set(delegators_balance_tzscan))
-        if not set(list(reward_data_rpc["delegators"].values())) == set(delegators_balance_tzscan):
-            raise Exception("Delegators' balances from local node and tzscan are not identical.")
-
-        blocks_rewards = int(reward_data_tzscan["blocks_rewards"])
-        future_blocks_rewards = int(reward_data_tzscan["future_blocks_rewards"])
-        endorsements_rewards = int(reward_data_tzscan["endorsements_rewards"])
-        future_endorsements_rewards = int(reward_data_tzscan["future_endorsements_rewards"])
-        lost_rewards_denounciation = int(reward_data_tzscan["lost_rewards_denounciation"])
-        lost_fees_denounciation = int(reward_data_tzscan["lost_fees_denounciation"])
-        fees = int(reward_data_tzscan["fees"])
-
-        total_rewards_tzscan = (blocks_rewards + endorsements_rewards + future_blocks_rewards +
-                              future_endorsements_rewards + fees - lost_rewards_denounciation - lost_fees_denounciation)
-
-        if not reward_data_rpc["total_rewards"] == total_rewards_tzscan:
-            raise Exception("Total rewards from local node and tzscan are not identical.")
-        
-    def __validate_reward_shares(self, pymnt_logs_rpc, total_rewards_rpc, pymnt_logs_tzscan, total_rewards_tzscan):
-        if pymnt_logs_rpc is None or total_rewards_rpc is None:
-            return pymnt_logs_tzscan, total_rewards_tzscan
-        
-        if not total_rewards_rpc == total_rewards_tzscan:
-            raise Exception("Total rewards from local node and tzscan are not identical.")
-        
-        for reward_item_rpc in pymnt_logs_rpc:
-            address_rpc = reward_item_rpc.address
-            for reward_item_tzscan in pymnt_logs_tzscan:
-                if address_rpc == reward_item_tzscan.address:
-                    if reward_item_tzscan.ratio != reward_item_rpc.ratio or reward_item_tzscan.reward != reward_item_rpc.reward:
-                        raise Exception("Reward calculations for {} from local node do not match tzscan results.".format(address_rpc))
-                    pymnt_logs_tzscan.remove(reward_item_tzscan)
-        
-        return pymnt_logs_rpc, total_rewards_rpc
 
     def waint_until_next_cycle(self, nb_blocks_remaining):
         for x in range(nb_blocks_remaining):
@@ -288,14 +223,14 @@ class PaymentProducer(threading.Thread):
                             payment_cycle, pymnt_log.address, pymnt_log.payment, pymnt_log.fee,
                             pymnt_log.type)
 
-    def make_payment_calculations(self, payment_cycle, reward_data, reward_calculator_api):
+    def make_payment_calculations(self, payment_cycle, reward_data):
 
         if reward_data["delegators_nb"] == 0:
             logger.warn("No delegators at cycle {}. Check your delegation status".format(payment_cycle))
             return [], 0
 
-        
-        rewards, total_rewards = reward_calculator_api.calculate(reward_data)
+
+        rewards, total_rewards = self.reward_calculator_api.calculate(reward_data)
 
         logger.info("Total rewards={}".format(total_rewards))
 

--- a/src/rpc/rpc_block_api.py
+++ b/src/rpc/rpc_block_api.py
@@ -1,0 +1,43 @@
+from api.block_api import BlockApi
+from util.rpc_utils import parse_json_response
+
+COMM_HEAD = " rpc get http://{}/chains/main/blocks/head"
+COMM_REVELATION = " rpc get http://{}/chains/main/blocks/head/context/contracts/{}/manager_key"
+
+class RpcBlockApiImpl(BlockApi):
+
+    def __init__(self, nw, wllt_clnt_mngr, node_url):
+        super(RpcBlockApiImpl, self).__init__(nw)
+        
+        self.wllt_clnt_mngr = wllt_clnt_mngr
+        self.node_url = node_url
+        
+    def get_current_level(self, verbose=False):
+        response = self.wllt_clnt_mngr.send_request(COMM_HEAD.format(self.node_url))
+        head = parse_json_response(response)
+        current_level = int(head["metadata"]["level"]["level"])
+        return current_level
+
+    def get_revelation(self, pkh, verbose=False):
+        response = self.wllt_clnt_mngr.send_request(COMM_REVELATION.format(self.node_url, pkh))
+        print(response)
+        manager_key = parse_json_response(response)
+        print(manager_key.keys())
+        bool_revelation = "key" in manager_key.keys() and len(manager_key["key"]) > 0
+        print(bool_revelation)         
+        return bool_revelation
+
+
+
+
+
+from cli.wallet_client_manager import WalletClientManager
+
+def test_get_revelation():
+    
+    wllt_clnt_mngr = WalletClientManager("~/tezos-alpha/tezos-client", "", "", "", True)
+
+    address_api = RpcBlockApiImpl({"NAME":"ALPHANET"}, wllt_clnt_mngr, "127.0.0.1:8732")
+    address_api.get_revelation("tz1N5cvoGZFNYWBp2NbCWhaRXuLQf6e1gZrv")
+    address_api.get_revelation("KT1FXQjnbdqDdKNpjeM6o8PF1w8Rn2j8BmmG")
+    address_api.get_revelation("tz1YVxe7FFisREKXWNxdrrwqvw3o2jeXzaNb")

--- a/src/rpc/rpc_block_api.py
+++ b/src/rpc/rpc_block_api.py
@@ -20,14 +20,9 @@ class RpcBlockApiImpl(BlockApi):
 
     def get_revelation(self, pkh, verbose=False):
         response = self.wllt_clnt_mngr.send_request(COMM_REVELATION.format(self.node_url, pkh))
-        print(response)
         manager_key = parse_json_response(response)
-        print(manager_key.keys())
         bool_revelation = "key" in manager_key.keys() and len(manager_key["key"]) > 0
-        print(bool_revelation)         
         return bool_revelation
-
-
 
 
 
@@ -38,6 +33,6 @@ def test_get_revelation():
     wllt_clnt_mngr = WalletClientManager("~/tezos-alpha/tezos-client", "", "", "", True)
 
     address_api = RpcBlockApiImpl({"NAME":"ALPHANET"}, wllt_clnt_mngr, "127.0.0.1:8732")
-    address_api.get_revelation("tz1N5cvoGZFNYWBp2NbCWhaRXuLQf6e1gZrv")
-    address_api.get_revelation("KT1FXQjnbdqDdKNpjeM6o8PF1w8Rn2j8BmmG")
-    address_api.get_revelation("tz1YVxe7FFisREKXWNxdrrwqvw3o2jeXzaNb")
+    print(address_api.get_revelation("tz1N5cvoGZFNYWBp2NbCWhaRXuLQf6e1gZrv"))
+    print(address_api.get_revelation("KT1FXQjnbdqDdKNpjeM6o8PF1w8Rn2j8BmmG"))
+    print(address_api.get_revelation("tz1YVxe7FFisREKXWNxdrrwqvw3o2jeXzaNb"))

--- a/src/rpc/rpc_reward_api.py
+++ b/src/rpc/rpc_reward_api.py
@@ -1,0 +1,124 @@
+from api.reward_api import RewardApi
+
+from log_config import main_logger
+from util.rpc_utils import parse_json_response
+
+logger = main_logger
+
+COMM_HEAD = " rpc get http://{}/chains/main/blocks/head"
+COMM_DELEGATES = " rpc get http://{}/chains/main/blocks/{}/context/delegates/{}"
+COMM_BLOCK = " rpc get http://{}/chains/main/blocks/{}~{}/"
+COMM_SNAPSHOT = COMM_BLOCK + "context/raw/json/rolls/owner/snapshot/{}/"
+COMM_DELEGATE_BALANCE = " rpc get http://{}/chains/main/blocks/{}/context/contracts/{}"
+
+
+class RpcRewardApiImpl(RewardApi):
+
+    def __init__(self, nw, baking_address, wllt_clnt_mngr, node_url):
+        super(RpcRewardApiImpl, self).__init__()
+
+        self.blocks_per_cycle = nw['BLOCKS_PER_CYCLE']  
+        self.preserved_cycles = nw['NB_FREEZE_CYCLE']
+        self.blocks_per_roll_snapshot = nw['BLOCKS_PER_ROLL_SNAPSHOT']
+        
+        self.baking_address = baking_address
+        self.wllt_clnt_mngr = wllt_clnt_mngr
+        self.node_url = node_url
+
+
+    def get_nb_delegators(self, cycle, verbose=False):
+        _, delegators = self.__get_delegators_and_delgators_balance(cycle)
+        return len(delegators)
+
+
+    def get_rewards_for_cycle_map(self, cycle, verbose=False):
+
+        reward_data = {}
+        
+        reward_data["delegate_staking_balance"], reward_data["delegators"] = self.__get_delegators_and_delgators_balance(cycle)      
+        reward_data["delegators_nb"] = len(reward_data["delegators"])
+        
+        current_level, head_hash = self.__get_current_level(verbose)        
+
+        # Get last block in cycle where rewards are unfrozen
+        level_for_relevant_request = (cycle + self.preserved_cycles + 1) * self.blocks_per_cycle
+
+        if current_level - level_for_relevant_request >= 0:
+            request_metadata = COMM_BLOCK.format(self.node_url, head_hash, current_level - level_for_relevant_request)+'/metadata/'
+            response_metadata = self.wllt_clnt_mngr.send_request(request_metadata)
+            metadata = parse_json_response(response_metadata)
+            balance_updates = metadata["balance_updates"]
+
+            unfrozen_rewards = unfrozen_fees = 0
+            for i in range(len(balance_updates)):
+                balance_update = balance_updates[i]
+                if balance_update["kind"] == "freezer":
+                    if balance_update["delegate"] == self.baking_address:
+                        if balance_update["category"] == "rewards":
+                            unfrozen_rewards = -int(balance_update["change"])
+                        elif balance_update["category"] == "fees":
+                            unfrozen_fees = -int(balance_update["change"])
+            reward_data["total_rewards"] = unfrozen_rewards + unfrozen_fees
+        else:
+            logger.warn("Please wait until the rewards and fees for cycle {} are unfrozen".format(cycle))        
+            reward_data["total_rewards"] = 0
+        
+        return reward_data
+
+    def __get_current_level(self, verbose=False):
+        response = self.wllt_clnt_mngr.send_request(COMM_HEAD.format(self.node_url))
+        head = parse_json_response(response)
+        current_level = int(head["metadata"]["level"]["level"])
+        head_hash = head["hash"]
+        return current_level, head_hash
+        
+    def __get_delegators_and_delgators_balance(self, cycle, verbose=False):
+        
+        hash_snapshot_block = self.__get_snapshot_block_hash(cycle)
+        if hash_snapshot_block == "":
+            return 0, []
+            
+        request = COMM_DELEGATES.format(self.node_url, hash_snapshot_block, self.baking_address)
+        response = self.wllt_clnt_mngr.send_request(request)
+        
+        delegate_staking_balance = 0
+        delegators = {}
+        
+        try:
+            response = parse_json_response(response)
+            delegate_staking_balance = int(response["staking_balance"])
+
+            delegators_addresses = response["delegated_contracts"]
+            for delegator in delegators_addresses:
+                request = COMM_DELEGATE_BALANCE.format(self.node_url, hash_snapshot_block, delegator)
+                response = self.wllt_clnt_mngr.send_request(request)
+                response = parse_json_response(response)
+                delegators[delegator] = int(response["balance"])
+        except:
+            logger.warn('No delegators or unexpected error')
+        
+        return delegate_staking_balance, delegators
+        
+    def __get_snapshot_block_hash(self, cycle, verbose=False):
+        
+        current_level, head_hash = self.__get_current_level(verbose)
+        
+        level_for_snapshot_request = (cycle - self.preserved_cycles) * self.blocks_per_cycle + 1    
+
+        if current_level - level_for_snapshot_request >= 0:
+            request = COMM_SNAPSHOT.format(self.node_url, head_hash, current_level - level_for_snapshot_request, cycle)
+            response = self.wllt_clnt_mngr.send_request(request)
+            snapshots = parse_json_response(response)
+    
+            if len(snapshots) == 1:
+                chosen_snapshot = snapshots[0]
+            else:
+                logger.info("Too few or too many possible snapshots found!")
+            
+            level_snapshot_block = (cycle - self.preserved_cycles - 2) * self.blocks_per_cycle + ( chosen_snapshot + 1 ) * self.blocks_per_roll_snapshot
+            request = COMM_BLOCK.format(self.node_url, head_hash, current_level - level_snapshot_block) + " | jq -r .hash"
+            hash_snapshot_block = self.wllt_clnt_mngr.send_request(request).rstrip()
+            return hash_snapshot_block
+        else:
+            logger.info("Cycle too far in the future")
+            return ""

--- a/src/rpc/rpc_reward_calculator.py
+++ b/src/rpc/rpc_reward_calculator.py
@@ -1,0 +1,64 @@
+from api.reward_calculator_api import RewardCalculatorApi
+
+from log_config import main_logger
+from util.rounding_command import RoundingCommand
+from model.payment_log import PaymentRecord
+
+logger = main_logger
+
+MUTEZ = 1000000
+
+class RpcRewardCalculatorApi(RewardCalculatorApi):
+
+    def __init__(self, founders_map, min_delegation_amt, excluded_set, rc=RoundingCommand(None)):
+        super(RpcRewardCalculatorApi, self).__init__(founders_map, excluded_set)
+        self.min_delegation_amt_mutez = min_delegation_amt * MUTEZ
+        self.logger = main_logger
+        self.rc = rc
+
+
+    def calculate(self, reward_data, verbose=False):
+        total_rewards = 0
+        rewards = []
+        
+        delegate_staking_balance, delegators = reward_data["delegate_staking_balance"], reward_data["delegators"]
+        
+        if len(delegators) > 0:        
+            
+            total_rewards = reward_data["total_rewards"] / MUTEZ
+            
+            if total_rewards > 0:        
+            
+                effective_delegate_staking_balance = delegate_staking_balance
+                effective_delegator_addresses = []
+        
+                # excluded addresses are processed
+                for address in delegators:
+                    balance = delegators[address]
+        
+                    if address in self.excluded_set:
+                        effective_delegate_staking_balance -= balance
+                        continue
+                    effective_delegator_addresses.append(address)
+        
+                
+                
+                # calculate how rewards will be distributed
+                for address in effective_delegator_addresses:
+                    balance = delegators[address]
+        
+                    # Skip those that did not delegate minimum amount
+                    if balance < self.min_delegation_amt_mutez:
+                        self.logger.debug("Skipping '{}': Low delegation amount ({:.6f})".format(address, (balance / MUTEZ)))
+                        continue
+        
+                    ratio = self.rc.round(balance / effective_delegate_staking_balance)
+                    reward = (total_rewards * ratio)
+                    
+#                    print(address, str(ratio*100) + ' %   -->   ', reward)
+                    
+                    reward_item = PaymentRecord(address=address, reward=reward, ratio=ratio)
+                    
+                    rewards.append(reward_item)
+
+        return rewards, total_rewards

--- a/src/tzscan/tzscan_reward_calculator.py
+++ b/src/tzscan/tzscan_reward_calculator.py
@@ -9,27 +9,28 @@ MUTEZ = 1000000
 
 class TzScanRewardCalculatorApi(RewardCalculatorApi):
     # reward_data : payment map returned from tzscan
-    def __init__(self, founders_map, reward_data, min_delegation_amt, excluded_set, rc=RoundingCommand(None)):
+    def __init__(self, founders_map, min_delegation_amt, excluded_set, rc=RoundingCommand(None)):
         super(TzScanRewardCalculatorApi, self).__init__(founders_map, excluded_set)
-        self.reward_data = reward_data
         self.min_delegation_amt_mutez = min_delegation_amt * MUTEZ
         self.logger = main_logger
         self.rc = rc
 
     ##
     # return rewards    : tuple (list of PaymentRecord objects, total rewards)
-    def calculate(self):
-        root = self.reward_data
+    def calculate(self, reward_data):
+        root = reward_data
 
         delegate_staking_balance = int(root["delegate_staking_balance"])
         blocks_rewards = int(root["blocks_rewards"])
         future_blocks_rewards = int(root["future_blocks_rewards"])
         endorsements_rewards = int(root["endorsements_rewards"])
         future_endorsements_rewards = int(root["future_endorsements_rewards"])
+        lost_rewards_denounciation = int(root["lost_rewards_denounciation"])
+        lost_fees_denounciation = int(root["lost_fees_denounciation"])
         fees = int(root["fees"])
 
         self.total_rewards = (blocks_rewards + endorsements_rewards + future_blocks_rewards +
-                              future_endorsements_rewards + fees) / MUTEZ
+                              future_endorsements_rewards + fees - lost_rewards_denounciation - lost_fees_denounciation) / MUTEZ
 
         delegators_balance = root["delegators_balance"]
 

--- a/src/util/client_utils.py
+++ b/src/util/client_utils.py
@@ -5,10 +5,10 @@ DOCKER_CLIENT_EXE = "%network%.sh"
 DOCKER_CLIENT_EXE_SUFFIX = " client"
 REGULAR_CLIENT_EXE = "tezos-client"
 
-def get_client_path(search_paths, docker=None, network_config=None, verbose=None):
+def get_client_path(search_paths, docker=None, network_name=None, verbose=None):
     client_exe = REGULAR_CLIENT_EXE
     if docker:
-        client_exe = DOCKER_CLIENT_EXE.replace("%network%", network_config['NAME'].lower())
+        client_exe = DOCKER_CLIENT_EXE.replace("%network%", network_name.lower())
     for search_path in search_paths:
         expanded_path = os.path.expanduser(search_path)
         client_path = os.path.join(expanded_path, client_exe)


### PR DESCRIPTION
- As described in the comments in issue #63, the network config constants should now be set from the local node access using the rpc interface of the client. In case the local node is not accessible, they can be acquired from a public node (tzbeta). If this is also not possible, then default values are set.
- The bug described in #64 is fixed through adding the lost rewards and fees to the calculation equation of total rewards
- The complete dependency on tzscan (described in issue #7) is avoided through the use of rpc calls on the running local node. This can be activated when setting `BOOL_USE_LOCAL_NODE` to `True` in the payment_producer script (should be configured externally for a long term use) in case a local node is accessible (which should be the case anyway for payment ability). 
The calculation of delegation status is performed through parsing the relevant snapshot block for a specific cycle. 
The total rewards were calculated through parsing the balance updates of the block where the rewards get unfrozen.

P.S.: The current version supports only the calculation of already unfrozen rewards. If the rewards are still frozen(in case of the use of a negative RELEASE_OVERRIDE), then the user is warned to wait until the rewards get unfrozen.

UPDATE: If the user opts for using a local node, then reward shares are computed twice (1.only from local rpc calls and 2. only from tzscan apis). If the obtained results do not match in any aspect, an exception is raised. In this way, results can be double checked for correctness before being forwarded to the payment customer.
If  `BOOL_USE_LOCAL_NODE` is set to `False`, the TRD would depend only on tzscan. I would suggest to keep the default value to `False` until this new feature is fully tested.