### PR TITLE
Fix tzstats and destination map issues

### DIFF
--- a/src/calc/phased_payment_calculator.py
+++ b/src/calc/phased_payment_calculator.py
@@ -86,6 +86,7 @@ class PhasedPaymentCalculator:
         phase4 = CalculatePhase4(self.founders_map, self.owners_map)
         rwrd_logs, total_rwrd_amnt = phase4.calculate(rwrd_logs, total_rwrd_amnt)
 
+
         # calculate amounts
         phase_last = CalculatePhaseFinal()
         rwrd_logs, total_rwrd_amnt = phase_last.calculate(rwrd_logs, total_rwrd_amnt)

--- a/src/pay/batch_payer.py
+++ b/src/pay/batch_payer.py
@@ -248,7 +248,7 @@ class BatchPayer():
 
             op_counter.inc()
 
-            content = CONTENT.replace("%SOURCE%", self.source).replace("%DESTINATION%", payment_item.address) \
+            content = CONTENT.replace("%SOURCE%", self.source).replace("%DESTINATION%", payment_item.paymentaddress) \
                 .replace("%AMOUNT%", str(pymnt_amnt)).replace("%COUNTER%", str(op_counter.get())) \
                 .replace("%fee%", self.default_fee).replace("%gas_limit%", self.gas_limit).replace("%storage_limit%", self.storage_limit)
 

--- a/src/rpc/rpc_reward_api.py
+++ b/src/rpc/rpc_reward_api.py
@@ -20,6 +20,8 @@ class RpcRewardApiImpl(RewardApi):
     def __init__(self, nw, baking_address, node_url, verbose=True):
         super(RpcRewardApiImpl, self).__init__()
 
+        self.name = 'RPC'
+
         self.blocks_per_cycle = nw['BLOCKS_PER_CYCLE']
         self.preserved_cycles = nw['NB_FREEZE_CYCLE']
         self.blocks_per_roll_snapshot = nw['BLOCKS_PER_ROLL_SNAPSHOT']

--- a/src/tzstats/tzstats_api_constants.py
+++ b/src/tzstats/tzstats_api_constants.py
@@ -1,7 +1,5 @@
 # Income
-idx_income_balance = 4
-idx_income_delegated = 5
-
+idx_income_expected_income = 19
 idx_income_total_income = 21
 idx_income_total_bonds = 22
 
@@ -23,5 +21,8 @@ idx_income_lost_revelation_fees = 36
 idx_income_lost_revelation_rewards = 37
 
 #snapshot
-idx_delegator_address = 15
+idx_baker_balance = 11
+idx_baker_delegated = 12
+
 idx_delegator_balance = 11
+idx_delegator_address = 15

--- a/src/tzstats/tzstats_reward_api.py
+++ b/src/tzstats/tzstats_reward_api.py
@@ -12,12 +12,14 @@ class TzStatsRewardApiImpl(RewardApi):
     def __init__(self, nw, baking_address, verbose=False):
         super().__init__()
 
+        self.name = 'tzstats'
+
         self.verbose = verbose
         self.logger = main_logger
         self.helper = TzStatsRewardProviderHelper(nw, baking_address)
 
-    def get_rewards_for_cycle_map(self, cycle):
-        root = self.helper.get_rewards_for_cycle(cycle, self.verbose)
+    def get_rewards_for_cycle_map(self, cycle, expected_reward = False):
+        root = self.helper.get_rewards_for_cycle(cycle, expected_reward, self.verbose)
 
         delegate_staking_balance = root["delegate_staking_balance"]
 

--- a/src/util/csv_payment_file_parser.py
+++ b/src/util/csv_payment_file_parser.py
@@ -36,4 +36,4 @@ class CsvPaymentFileParser:
 
             for pl in payment_logs:
                 # write row to csv file
-                csv_writer.writerow([pl.address, pl.type, pl.amount, pl.hash if pl.hash else "None", pl.paid.value])
+                csv_writer.writerow([pl.paymentaddress, pl.type, pl.amount, pl.hash if pl.hash else "None", pl.paid.value])


### PR DESCRIPTION
* Fix tzstats issues: As noted in the last PR, tzstats was in testing period and was therefore not set as default. We noticed that the staking balance given by tzstats should be retrieved from the snapshot call and not from the income call, otherwise (differently from tzscan) the staking balance of the payout cycle and not of the snapshot cycle will be taken as reference.
Furthermore, we added the possibility to get reward data of upcoming cycles based on the expected income (resolves #128).
HOWEVER, since tzstats does not allow commercial use only under previous agreement and that could be taken for granted, we will keep on not using tzstats as default. PRPC will be still the default, using tzstats should be explicitly set through the -P tzstats flag, and under personal guarantee in case of commercial use.
* destination map issues (resolves #120)