### PR TITLE
Support paying burn fee to reactivate zeroed tz1 address

### DIFF
--- a/examples/tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889.yaml
+++ b/examples/tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889.yaml
@@ -7,9 +7,9 @@ owners_map : {tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889: 0.3, KT1KLQbYFtFZ5mAEnfEMZaW
 specials_map : {KT19g4JHTd3QYuYcpKFFiwViEzQ5n6ovYx1V: 7.5}
 supporters_set : {KT1SenDhs9rL9fpZV3cLRXFovEBafmGqkki8}
 min_delegation_amt : 1000
-reactivate_zeroed_account : False
+reactivate_zeroed : False
 delegator_pays_xfer_fee : True
-delegator_pays_reactivation_fee : True
+delegator_pays_ra_fee : True
 rules_map:
   KT1MMhmTkUoHez4u58XMZL7NkpU9FWY4QLn3: KT1MMhmTkUoHez4u58XMZL7NkpU9FWY4QLn0
   KT1D33n8zp1bqBkViiQtLLPLEGRW9xcqihY3: KT1MMhmTkUoHez4u58XMZL7NkpU9FWY4QLn0

--- a/examples/tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889.yaml
+++ b/examples/tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889.yaml
@@ -7,7 +7,9 @@ owners_map : {tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889: 0.3, KT1KLQbYFtFZ5mAEnfEMZaW
 specials_map : {KT19g4JHTd3QYuYcpKFFiwViEzQ5n6ovYx1V: 7.5}
 supporters_set : {KT1SenDhs9rL9fpZV3cLRXFovEBafmGqkki8}
 min_delegation_amt : 1000
+reactivate_zeroed_account : False
 delegator_pays_xfer_fee : True
+delegator_pays_reactivation_fee : True
 rules_map:
   KT1MMhmTkUoHez4u58XMZL7NkpU9FWY4QLn3: KT1MMhmTkUoHez4u58XMZL7NkpU9FWY4QLn0
   KT1D33n8zp1bqBkViiQtLLPLEGRW9xcqihY3: KT1MMhmTkUoHez4u58XMZL7NkpU9FWY4QLn0

--- a/src/calc/calculate_phase0.py
+++ b/src/calc/calculate_phase0.py
@@ -33,14 +33,19 @@ class CalculatePhase0(CalculatePhaseBase):
         reward_logs = []
         delegate_staking_balance = self.reward_provider_model.delegate_staking_balance
         delegators_balance_dict = self.reward_provider_model.delegator_balance_dict
+
         # calculate how rewards will be distributed
         # ratio is stake/total staking balance
         # total of ratios must be 1
-        for address, balance in delegators_balance_dict.items():
-            total_delegator_balance += balance
 
-            ratio = balance / delegate_staking_balance
-            reward_item = RewardLog(address=address, type=reward_log.TYPE_DELEGATOR, balance=balance)
+        for address, delegator_info in delegators_balance_dict.items():
+
+            staking_balance = delegator_info["staking_balance"]
+            current_balance = delegator_info["current_balance"]
+            total_delegator_balance += staking_balance
+
+            ratio = staking_balance / delegate_staking_balance
+            reward_item = RewardLog(address=address, type=reward_log.TYPE_DELEGATOR, staking_balance=staking_balance, current_balance=current_balance)
             reward_item.ratio = ratio
             reward_item.ratio0 = reward_item.ratio
 
@@ -49,7 +54,8 @@ class CalculatePhase0(CalculatePhaseBase):
             reward_logs.append(reward_item)
 
         owners_rl = RewardLog(address=reward_log.TYPE_OWNERS_PARENT, type=reward_log.TYPE_OWNERS_PARENT,
-                              balance=delegate_staking_balance - total_delegator_balance)
+                              staking_balance=delegate_staking_balance - total_delegator_balance,
+                              current_balance=0)
         owners_rl.ratio = (1 - ratio_sum)
         owners_rl.ratio0 = owners_rl.ratio
 

--- a/src/calc/calculate_phase1.py
+++ b/src/calc/calculate_phase1.py
@@ -38,15 +38,15 @@ class CalculatePhase1(CalculatePhaseBase):
 
         # exclude requested addresses from reward list
         for rl0 in reward_data0:
-            total_balance += rl0.balance
+            total_balance += rl0.staking_balance
             if rl0.address in self.excluded_set:
                 rl0.skip(desc=BY_CONFIGURATION, phase=self.phase)
                 rewards.append(rl0)
-                total_balance_excluded += rl0.balance
-            elif MIN_DELEGATION_KEY in self.excluded_set and rl0.balance < self.min_delegation_amount:
+                total_balance_excluded += rl0.staking_balance
+            elif MIN_DELEGATION_KEY in self.excluded_set and rl0.staking_balance < self.min_delegation_amount:
                 rl0.skip(desc=BY_MIN_DELEGATION, phase=self.phase)
                 rewards.append(rl0)
-                total_balance_excluded += rl0.balance
+                total_balance_excluded += rl0.staking_balance
             else:
                 # ratio will be replaced with actual ratio, read below
                 rewards.append(rl0)
@@ -55,7 +55,7 @@ class CalculatePhase1(CalculatePhaseBase):
 
         # calculate new ratio using remaining balance
         for rl1 in self.filterskipped(rewards):
-            rl1.ratio = rl1.balance / new_total_balance
+            rl1.ratio = rl1.staking_balance / new_total_balance
             rl1.ratio1 = rl1.ratio
 
         # total reward amount needs to be diminished at the same rate total balance diminishes

--- a/src/calc/calculate_phase2.py
+++ b/src/calc/calculate_phase2.py
@@ -39,16 +39,16 @@ class CalculatePhase2(CalculatePhaseBase):
         # exclude requested addresses from reward list
         for rl1 in self.filterskipped(reward_data1):
 
-            total_balance += rl1.balance
+            total_balance += rl1.staking_balance
 
             if rl1.address in self.excluded_set:
                 rl1.skip(desc=BY_CONFIGURATION, phase=self.phase)
                 rewards.append(rl1)
-                total_balance_excluded += rl1.balance
-            elif MIN_DELEGATION_KEY in self.excluded_set and rl1.balance < self.min_delegation_amount:
+                total_balance_excluded += rl1.staking_balance
+            elif MIN_DELEGATION_KEY in self.excluded_set and rl1.staking_balance < self.min_delegation_amount:
                 rl1.skip(desc=BY_MIN_DELEGATION, phase=self.phase)
                 rewards.append(rl1)
-                total_balance_excluded += rl1.balance
+                total_balance_excluded += rl1.staking_balance
             else:
                 # ratio2 will be replaced with actual ratio, read below
                 rewards.append(rl1)
@@ -57,7 +57,7 @@ class CalculatePhase2(CalculatePhaseBase):
 
         # calculate new ratio using remaining balance
         for rl2 in self.filterskipped(rewards):
-            rl2.ratio = rl2.balance / new_total_balance
+            rl2.ratio = rl2.staking_balance / new_total_balance
             rl2.ratio2 = rl2.ratio
 
         # total reward amount remains the same

--- a/src/calc/calculate_phase3.py
+++ b/src/calc/calculate_phase3.py
@@ -9,7 +9,7 @@ class CalculatePhase3(CalculatePhaseBase):
     """
     -- Phase3 : Founders Phase --
 
-    At stage 3, Founders record is created. Founders record is later on splitted into founder records, for each founder.
+    At stage 3, Founders record is created. Founders record is later split into founder records, for each founder.
     If any address is excluded at this stage, its reward is given to founders.
     Fee rates are set at this stage.
     """
@@ -37,7 +37,7 @@ class CalculatePhase3(CalculatePhaseBase):
                 rl2.skip(desc=BY_CONFIGURATION, phase=self.phase)
                 new_rewards.append(rl2)
                 total_excluded_ratio += rl2.ratio
-            elif MIN_DELEGATION_KEY in self.excluded_set and rl2.balance < self.min_delegation_amount:
+            elif MIN_DELEGATION_KEY in self.excluded_set and rl2.staking_balance < self.min_delegation_amount:
                 rl2.skip(desc=BY_MIN_DELEGATION, phase=self.phase)
                 new_rewards.append(rl2)
                 total_excluded_ratio += rl2.ratio
@@ -57,7 +57,7 @@ class CalculatePhase3(CalculatePhaseBase):
 
         # create founders parent record
         if total_service_fee_ratio > 1e-6:  # >0
-            rl = RewardLog(address=TYPE_FOUNDERS_PARENT, type=TYPE_FOUNDERS_PARENT, balance=0)
+            rl = RewardLog(address=TYPE_FOUNDERS_PARENT, type=TYPE_FOUNDERS_PARENT, staking_balance=0, current_balance=0)
             rl.service_fee_rate = 0
             rl.service_fee_ratio = 0
             rl.ratio = total_service_fee_ratio

--- a/src/calc/calculate_phase4.py
+++ b/src/calc/calculate_phase4.py
@@ -31,7 +31,7 @@ class CalculatePhase4(CalculatePhaseBase):
         for rl3 in self.filterskipped(reward_data3):
             if rl3.type == TYPE_FOUNDERS_PARENT:
                 for addr, ratio in self.founders_map.items():
-                    rl4 = RewardLog(addr, TYPE_FOUNDER, 0)
+                    rl4 = RewardLog(addr, TYPE_FOUNDER, 0, 0)
                     # new ratio is parent ratio * ratio of the founder
                     rl4.ratio = ratio * rl3.ratio
                     rl4.ratio4 = rl4.ratio
@@ -46,7 +46,7 @@ class CalculatePhase4(CalculatePhaseBase):
 
             elif rl3.type == TYPE_OWNERS_PARENT:
                 for addr, ratio in self.owners_map.items():
-                    rl4 = RewardLog(addr, TYPE_OWNER, ratio * rl3.staking_balance)
+                    rl4 = RewardLog(addr, TYPE_OWNER, ratio * rl3.staking_balance, 0)
                     # new ratio is parent ratio * ratio of the owner
                     rl4.ratio = ratio * rl3.ratio
                     rl4.ratio4 = rl4.ratio

--- a/src/calc/calculate_phase4.py
+++ b/src/calc/calculate_phase4.py
@@ -46,7 +46,7 @@ class CalculatePhase4(CalculatePhaseBase):
 
             elif rl3.type == TYPE_OWNERS_PARENT:
                 for addr, ratio in self.owners_map.items():
-                    rl4 = RewardLog(addr, TYPE_OWNER, ratio * rl3.balance)
+                    rl4 = RewardLog(addr, TYPE_OWNER, ratio * rl3.staking_balance)
                     # new ratio is parent ratio * ratio of the owner
                     rl4.ratio = ratio * rl3.ratio
                     rl4.ratio4 = rl4.ratio

--- a/src/calc/calculate_phase5.py
+++ b/src/calc/calculate_phase5.py
@@ -25,5 +25,4 @@ class CalculatePhase5(CalculatePhaseBase):
             if rl.address in self.addr_dest_dict:
                 rl.paymentaddress = self.addr_dest_dict[rl.address]
 
-
         return reward_data4, total_amount

--- a/src/calc/calculate_phase6.py
+++ b/src/calc/calculate_phase6.py
@@ -34,7 +34,7 @@ class CalculatePhase6(CalculatePhaseBase):
 
         for addr, rl_list in payment_address_list_dict.items():
             if len(rl_list) > 1:
-                total_balance = sum([rl.balance for rl in rl_list])
+                total_balance = sum([rl.staking_balance for rl in rl_list])
                 total_ratio = sum([rl.ratio for rl in rl_list])
                 total_payment_amount = sum([rl.amount for rl in rl_list])
                 total_service_fee_amount = sum([rl.service_fee_amount for rl in rl_list])

--- a/src/calc/calculate_phase7.py
+++ b/src/calc/calculate_phase7.py
@@ -1,0 +1,39 @@
+from log_config import main_logger
+from model import reward_log
+from calc.calculate_phase_base import CalculatePhaseBase, BY_ZERO_BALANCE
+
+logger = main_logger
+
+class CalculatePhase7(CalculatePhaseBase):
+    """
+    -- Phase7 : Check if current delegator balance is 0 --
+
+    At stage 7, check each delegate's current balance. If 0, and baker is not reactivating,
+    then mark payment as not-payable
+    """
+
+    def __init__(self, reactivate_zeroed) -> None:
+        super().__init__()
+        self.reactivate_zeroed = reactivate_zeroed
+        self.phase = 7
+
+    def calculate(self, reward_logs):
+
+        reward_data7 = []
+
+        for delegate in reward_logs:
+
+            # If delegate's current balance is 0, and we are NOT reactivating it,
+            # then mark address as being skipped with a description to be included
+            # in the CSV payment report
+
+            if (delegate.type == reward_log.TYPE_DELEGATOR and delegate.current_balance == 0):
+
+                if self.reactivate_zeroed:
+                    delegate.needs_activation = True
+                else:
+                    delegate.skip(BY_ZERO_BALANCE, self.phase)
+
+            reward_data7.append(delegate)
+
+        return reward_data7

--- a/src/calc/calculate_phase_base.py
+++ b/src/calc/calculate_phase_base.py
@@ -4,6 +4,7 @@ import itertools
 
 BY_CONFIGURATION = "Excluded by configuration"
 BY_MIN_DELEGATION = "Excluded by min delegation"
+BY_ZERO_BALANCE = "Excluded by zero balance"
 
 class CalculatePhaseBase(ABC):
 

--- a/src/calc/phased_payment_calculator.py
+++ b/src/calc/phased_payment_calculator.py
@@ -49,7 +49,7 @@ class PhasedPaymentCalculator:
             logger.debug("NO REWARDS to process!")
             return [], 0
 
-        assert reward_provider_model.delegate_staking_balance == sum([rl.balance for rl in rwrd_logs])
+        assert reward_provider_model.delegate_staking_balance == sum([rl.staking_balance for rl in rwrd_logs])
         assert self.almost_equal(1, sum([rl.ratio for rl in rwrd_logs]))
 
         # calculate phase 1
@@ -85,7 +85,6 @@ class PhasedPaymentCalculator:
 
         phase4 = CalculatePhase4(self.founders_map, self.owners_map)
         rwrd_logs, total_rwrd_amnt = phase4.calculate(rwrd_logs, total_rwrd_amnt)
-
 
         # calculate amounts
         phase_last = CalculatePhaseFinal()

--- a/src/calc/test_calculatePhase0.py
+++ b/src/calc/test_calculatePhase0.py
@@ -20,18 +20,19 @@ class TestCalculatePhase0(TestCase):
         phase0 = CalculatePhase0(model)
         reward_data, total_rewards = phase0.calculate()
 
-        staking_balance = int(model.delegate_staking_balance)
+        delegate_staking_balance = int(model.delegate_staking_balance)
 
         # total reward ratio is 1
         self.assertTrue(1.0, sum(r.ratio0 for r in reward_data))
 
         # check that ratio calculations are correct
-        delegators_balances = model.delegator_balance_dict
+        delegators_balances_dict = model.delegator_balance_dict
 
         # check ratios
-        for (address, balance), reward in zip(delegators_balances.items(),reward_data):
+        for (address, delegator_info), reward in zip(delegators_balances_dict.items(), reward_data):
             # ratio must be equal to stake/total staking balance
-            self.assertEqual(int(balance) / staking_balance, reward.ratio0)
+            delegator_staking_balance = int(delegator_info["staking_balance"])
+            self.assertEqual(delegator_staking_balance / delegate_staking_balance, reward.ratio0)
 
         # last one is owners record
         self.assertTrue(reward_data[-1].type == reward_log.TYPE_OWNERS_PARENT)

--- a/src/calc/test_calculatePhase1.py
+++ b/src/calc/test_calculatePhase1.py
@@ -11,7 +11,7 @@ class TestCalculatePhase1(TestCase):
         total_reward = 1000
 
         for i, ratio in enumerate(ratios,start=1):
-            rl0 = RewardLog(address="addr" + str(i), type="D", balance=total_reward * ratio)
+            rl0 = RewardLog(address="addr" + str(i), type="D", staking_balance=total_reward * ratio, current_balance=0)
             rl0.ratio0 = ratio
             rewards.append(rl0)
 

--- a/src/calc/test_calculatePhase2.py
+++ b/src/calc/test_calculatePhase2.py
@@ -11,11 +11,11 @@ class TestCalculatePhase2(TestCase):
         total_reward = 1000
 
         for i, addr in enumerate(ratios, start=1):
-            rl0 = RewardLog(address="addr" + str(i), type="D", balance=total_reward * ratios[addr])
+            rl0 = RewardLog(address="addr" + str(i), type="D", staking_balance=total_reward * ratios[addr], current_balance=0)
             rl0.ratio1 = ratios[addr]
             rewards.append(rl0)
 
-        rewards.append(RewardLog("addrdummy", "D", 0).skip("skipped for testing", 2))
+        rewards.append(RewardLog("addrdummy", "D", 0, 0).skip("skipped for testing", 2))
 
         excluded_set = {"addr1"}
 

--- a/src/calc/test_calculatePhase3.py
+++ b/src/calc/test_calculatePhase3.py
@@ -12,12 +12,12 @@ class TestCalculatePhase3(TestCase):
         total_reward = 1000
 
         for i, ratio in enumerate(ratios, start=1):
-            rl0 = RewardLog(address="addr" + str(i), type="D", balance=total_reward * ratio)
+            rl0 = RewardLog(address="addr" + str(i), type="D", staking_balance=total_reward * ratio, current_balance=0)
             rl0.ratio = ratio
             rl0.ratio2 = ratio
             rewards.append(rl0)
 
-        rewards.append(RewardLog("addrdummy", "D", 0).skip("skipped for testing", 2))
+        rewards.append(RewardLog("addrdummy", "D", 0, 0).skip("skipped for testing", 2))
 
         excluded_set = {"addr1"}
 
@@ -58,12 +58,12 @@ class TestCalculatePhase3(TestCase):
         total_reward = 1000
 
         for i, ratio in enumerate(ratios, start=1):
-            rl0 = RewardLog(address="addr" + str(i), type="D", balance=total_reward * ratio)
+            rl0 = RewardLog(address="addr" + str(i), type="D", staking_balance=total_reward * ratio, current_balance=0)
             rl0.ratio = ratio
             rl0.ratio2 = ratio
             rewards.append(rl0)
 
-        rewards.append(RewardLog("addrdummy", "D", 0).skip("skipped for testing", 2))
+        rewards.append(RewardLog("addrdummy", "D", 0, 0).skip("skipped for testing", 2))
 
         excluded_set = {"addr1"}
         supporters_set = {"addr2"}

--- a/src/calc/test_calculatePhase4.py
+++ b/src/calc/test_calculatePhase4.py
@@ -11,7 +11,7 @@ class TestCalculatePhase4(TestCase):
         total_reward = 1000
 
         for i, ratio in enumerate(ratios, start=1):
-            rl0 = RewardLog(address="addr" + str(i), type="D", balance=total_reward * ratio)
+            rl0 = RewardLog(address="addr" + str(i), type="D", staking_balance=total_reward * ratio, current_balance=0)
             rl0.ratio = ratio
             rl0.ratio3 = ratio
             rewards.append(rl0)
@@ -19,13 +19,12 @@ class TestCalculatePhase4(TestCase):
         rewards[0].type = TYPE_OWNERS_PARENT
         rewards[1].type = TYPE_FOUNDERS_PARENT
 
-        rewards.append(RewardLog("addrdummy", "D", 0).skip("skipped for testing", 3))
+        rewards.append(RewardLog("addrdummy", "D", 0, 0).skip("skipped for testing", 3))
 
         founders_map = {"addr1": 0.4, "addr2": 0.6}
         owners_map = {"addr1": 0.6, "addr2": 0.4}
 
         phase4 = CalculatePhase4(founders_map, owners_map)
-
         new_rewards, new_total_reward = phase4.calculate(rewards, total_reward)
 
         # new_total_reward = total_reward

--- a/src/calc/test_calculatePhase5.py
+++ b/src/calc/test_calculatePhase5.py
@@ -11,12 +11,12 @@ class TestCalculatePhase5(TestCase):
         total_reward = 1000
 
         for i, ratio in enumerate(ratios, start=1):
-            rl0 = RewardLog(address="addr" + str(i), type="D", balance=total_reward * ratio)
+            rl0 = RewardLog(address="addr" + str(i), type="D", staking_balance=total_reward * ratio, current_balance=0)
             rl0.ratio = ratio
             rl0.ratio4 = ratio
             rewards.append(rl0)
 
-        rewards.append(RewardLog("addrdummy","D",0).skip("skipped for testing",4))
+        rewards.append(RewardLog("addrdummy", "D" , 0, 0).skip("skipped for testing",4))
 
         phase5 = CalculatePhase5({"addr2":"addr1"})
 

--- a/src/cli/cmd_manager.py
+++ b/src/cli/cmd_manager.py
@@ -1,5 +1,5 @@
+import os
 from subprocess import STDOUT, check_output, TimeoutExpired, CalledProcessError
-
 from log_config import main_logger
 from util.client_utils import clear_terminal_chars
 
@@ -26,6 +26,7 @@ class CommandManager:
             logger.debug("--> Verbose : Command is |{}|".format(cmd))
 
         try:
+            os.environ["TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER"] = "Y"
             output = check_output(cmd, shell=True, stderr=STDOUT, timeout=timeout, encoding='utf8')
         except TimeoutExpired as e:
             logger.info("Command timed out")

--- a/src/configure.py
+++ b/src/configure.py
@@ -46,7 +46,7 @@ messages = {'hello':'This application will help you create configuration file fo
     , 'redirect' : "Add redirected address in form of PKH1,PKH2. Payments for PKH1 will go to PKH2. Type enter to skip"
     , 'reactivatezeroed' : "If a destination address has 0 balance, should burn fee be paid to reactivate? 1 for Yes, 0 for No. Type enter for Yes"
     , 'delegatorpaysxfrfee' : "Who is going to pay for transfer fees: 0 for delegator, 1 for delegate. Type enter for delegator"
-    , 'delegatorpaysrafee' : "Who is going to pay for 0XTZ-balance reactivation/burn fee: 0 for delegator, 1 for delegate. Type enter for delegator"
+    , 'delegatorpaysrafee' : "Who is going to pay for 0 balance reactivation/burn fee: 0 for delegator, 1 for delegate. Type enter for delegator"
     , 'supporters' : "Add supporter address. Supporters do not pay service fee. Type enter to skip"
     , 'specials' : "Add special fee in form of PKH,fee. Given addresses will pay the specified fee rate. Type enter to skip"
     , 'final' : "Add excluded address in form of PKH,target. Possbile targets are= TOB: leave at balance, TOF: to founders, TOE: to everybody. Type enter to skip"

--- a/src/configure.py
+++ b/src/configure.py
@@ -21,7 +21,8 @@ from launch_common import print_banner, add_argument_network, add_argument_repor
     add_argument_verbose, add_argument_dry, add_argument_provider
 from log_config import main_logger
 from model.baking_conf import BakingConf, BAKING_ADDRESS, PAYMENT_ADDRESS, SERVICE_FEE, FOUNDERS_MAP, OWNERS_MAP, \
-    MIN_DELEGATION_AMT, RULES_MAP, MIN_DELEGATION_KEY, DELEGATOR_PAYS_XFER_FEE, SPECIALS_MAP, SUPPORTERS_SET
+    MIN_DELEGATION_AMT, RULES_MAP, MIN_DELEGATION_KEY, DELEGATOR_PAYS_XFER_FEE, DELEGATOR_PAYS_RA_FEE, \
+    REACTIVATE_ZEROED, SPECIALS_MAP, SUPPORTERS_SET
 from util.address_validator import AddressValidator
 from util.client_utils import get_client_path
 from util.dir_utils import get_payment_root, \
@@ -43,7 +44,9 @@ messages = {'hello':'This application will help you create configuration file fo
     , 'mindelegationtarget' : "Specify where should shares of delegators failing to satisfy minimum delegation amount go. TOB: leave at balance, TOF: to founders, TOE: to everybody, default is TOB"
     , 'exclude' : "Add excluded address in form of PKH,target. Share of the exluded address will go to target. Possbile targets are= TOB: leave at balance, TOF: to founders, TOE: to everybody. Type enter to skip"
     , 'redirect' : "Add redirected address in form of PKH1,PKH2. Payments for PKH1 will go to PKH2. Type enter to skip"
-    , 'delegatorpays' : "Who is going to pay for transfer fees: 0 for delegator, 1 for delegate. Type enter for delegator"
+    , 'reactivatezeroed' : "If a destination address has 0 balance, should burn fee be paid to reactivate? 1 for Yes, 0 for No. Type enter for Yes"
+    , 'delegatorpaysxfrfee' : "Who is going to pay for transfer fees: 0 for delegator, 1 for delegate. Type enter for delegator"
+    , 'delegatorpaysrafee' : "Who is going to pay for 0XTZ-balance reactivation/burn fee: 0 for delegator, 1 for delegate. Type enter for delegator"
     , 'supporters' : "Add supporter address. Supporters do not pay service fee. Type enter to skip"
     , 'specials' : "Add special fee in form of PKH,fee. Given addresses will pay the specified fee rate. Type enter to skip"
     , 'final' : "Add excluded address in form of PKH,target. Possbile targets are= TOB: leave at balance, TOF: to founders, TOE: to everybody. Type enter to skip"
@@ -253,12 +256,34 @@ def onredirect(input):
         printe("Invalid redirection entry: " + traceback.format_exc())
         return
 
-def ondelegatorpays(input):
+def ondelegatorpaysxfrfee(input):
     try:
         if not input:
             input="0"
         global parser
         parser.set(DELEGATOR_PAYS_XFER_FEE, input!="1")
+    except:
+        printe("Invalid input: " + traceback.format_exc())
+        return
+    fsm.go()
+
+def ondelegatorpaysrafee(input):
+    try:
+        if not input:
+            input="1"
+        global parser
+        parser.set(DELEGATOR_PAYS_RA_FEE, input!="1")
+    except:
+        printe("Invalid input: " + traceback.format_exc())
+        return
+    fsm.go()
+
+def onreactivatezeroed(input):
+    try:
+        if not input:
+            input="1"
+        global parser
+        parser.set(REACTIVATE_ZEROED, input!="1")
     except:
         printe("Invalid input: " + traceback.format_exc())
         return
@@ -276,7 +301,9 @@ callbacks = {'bakingaddress':onbakingaddress
     ,'mindelegationtarget':onmindelegationtarget
     ,'exclude':onexclude
     ,'redirect':onredirect
-    ,'delegatorpays':ondelegatorpays
+    ,'reactivatezeroed':onreactivatezeroed
+    ,'delegatorpaysxfrfee':ondelegatorpaysxfrfee
+    ,'delegatorpaysrafee':ondelegatorpaysrafee
     ,'supporters':onsupporters
     ,'specials':onspecials
     ,'final':onfinal
@@ -293,8 +320,10 @@ fsm = Fysom({ 'initial': 'hello', 'final':'final',
                   {'name': 'go', 'src': 'mindelegation', 'dst': 'mindelegationtarget'},
                   {'name': 'go', 'src': 'mindelegationtarget', 'dst': 'exclude'},
                   {'name': 'go', 'src': 'exclude', 'dst': 'redirect'},
-                  {'name': 'go', 'src': 'redirect', 'dst': 'delegatorpays'},
-                  {'name': 'go', 'src': 'delegatorpays', 'dst': 'specials'},
+                  {'name': 'go', 'src': 'redirect', 'dst': 'reactivatezeroed'},
+                  {'name': 'go', 'src': 'reactivatezeroed', 'dst': 'delegatorpaysrafee'},
+                  {'name': 'go', 'src': 'delegatorpaysrafee', 'dst': 'delegatorpaysxfrfee'},
+                  {'name': 'go', 'src': 'delegatorpaysxfrfee', 'dst': 'specials'},
                   {'name': 'go', 'src': 'specials', 'dst': 'supporters'},
                   {'name': 'go', 'src': 'supporters', 'dst': 'final'} ],
               'callbacks': {

--- a/src/main.py
+++ b/src/main.py
@@ -154,6 +154,8 @@ def main(args):
         c = PaymentConsumer(name='consumer' + str(i), payments_dir=payments_root, key_name=payment_address,
                             client_path=client_path, payments_queue=payments_queue, node_addr=args.node_addr,
                             wllt_clnt_mngr=wllt_clnt_mngr, args=args, verbose=args.verbose, dry_run=dry_run,
+                            reactivate_zeroed=cfg.get_reactivate_zeroed(),
+                            delegator_pays_ra_fee=cfg.get_delegator_pays_ra_fee(),
                             delegator_pays_xfer_fee=cfg.get_delegator_pays_xfer_fee(), dest_map=cfg.get_dest_map(),
                             network_config=network_config,publish_stats=publish_stats)
         time.sleep(1)

--- a/src/model/baking_conf.py
+++ b/src/model/baking_conf.py
@@ -9,7 +9,9 @@ RULES_MAP = 'rules_map'
 SUPPORTERS_SET = 'supporters_set'
 PAYMENT_ADDRESS = 'payment_address'
 MIN_DELEGATION_AMT = 'min_delegation_amt'
+REACTIVATE_ZEROED = 'reactivate_zeroed'
 DELEGATOR_PAYS_XFER_FEE = 'delegator_pays_xfer_fee'
+DELEGATOR_PAYS_RA_FEE = 'delegator_pays_ra_fee'
 ### extensions
 FULL_SUPPORTERS_SET = "__full_supporters_set"
 EXCLUDED_DELEGATORS_SET_TOB = "__excluded_delegators_set_tob"
@@ -69,8 +71,14 @@ class BakingConf:
     def get_min_delegation_amount(self):
         return self.get_attribute(MIN_DELEGATION_AMT)
 
+    def get_reactivate_zeroed(self):
+        return self.get_attribute(REACTIVATE_ZEROED)
+
     def get_delegator_pays_xfer_fee(self):
         return self.get_attribute(DELEGATOR_PAYS_XFER_FEE)
+
+    def get_delegator_pays_ra_fee(self):
+        return self.get_attribute(DELEGATOR_PAYS_RA_FEE)
 
     def get_rule_map(self):
         return self.get_attribute(RULES_MAP)

--- a/src/model/reward_log.py
+++ b/src/model/reward_log.py
@@ -22,11 +22,13 @@ class RunMode(Enum):
 
 
 class RewardLog:
-    def __init__(self, address, type, balance) -> None:
+    def __init__(self, address, type, staking_balance, current_balance) -> None:
         super().__init__()
-        self.balance = balance
+        self.staking_balance = staking_balance
+        self.current_balance = current_balance
         self.address = address
         self.paymentaddress = address
+        self.needs_activation = False
         self.type = type
         self.desc = ""
         self.skipped = False
@@ -61,11 +63,12 @@ class RewardLog:
         return self
 
     def __repr__(self) -> str:
-        return "address: %s, type: %s, balance: %s, disabled:%s" % (self.address, self.type, self.balance, self.skipped)
+        return "Address: {}, Type: {}, SB: {}, CB: {}, Skipped: {}, NA: {}".format(
+            self.address, self.type, self.staking_balance, self.current_balance, self.skipped, self.needs_activation)
 
     @staticmethod
     def ExitInstance():
-        return RewardLog(address=EXIT_PAYMENT_TYPE, type=EXIT_PAYMENT_TYPE, balance=0)
+        return RewardLog(address=EXIT_PAYMENT_TYPE, type=EXIT_PAYMENT_TYPE, staking_balance=0, current_balance=0)
 
     @staticmethod
     def ExternalInstance(file_name, address, amount):
@@ -80,14 +83,14 @@ def cmp_by_skip_type_balance(rl1, rl2):
              TYPE_MERGED: 0}
     if rl1.skipped == rl2.skipped:
         if rl1.type == rl2.type:
-            if rl1.balance is None:
+            if rl1.staking_balance is None:
                 return 1
-            if rl2.balance is None:
+            if rl2.staking_balance is None:
                 return -1
-            if rl1.balance == rl2.balance:
+            if rl1.staking_balance == rl2.staking_balance:
                 return 1
             else:
-                return rl2.balance - rl1.balance
+                return rl2.staking_balance - rl1.staking_balance
         else:
             return types[rl2.type] - types[rl1.type]
     else:
@@ -102,13 +105,13 @@ def cmp_by_type_balance(rl1, rl2):
              TYPE_MERGED: 0}
 
     if rl1.type == rl2.type:
-        if rl1.balance is None:
+        if rl1.staking_balance is None:
             return 1
-        if rl2.balance is None:
+        if rl2.staking_balance is None:
             return -1
-        if rl1.balance == rl2.balance:
+        if rl1.staking_balance == rl2.staking_balance:
             return 1
         else:
-            return rl2.balance - rl1.balance
+            return rl2.staking_balance - rl1.staking_balance
     else:
         return types[rl2.type] - types[rl1.type]

--- a/src/pay/batch_payer.py
+++ b/src/pay/batch_payer.py
@@ -33,7 +33,7 @@ COMM_WAIT = " wait for %OPERATION% to be included --confirmations {}".format(CON
 
 FEE_INI = 'fee.ini'
 MUTEZ = 1e6
-RA_BURN_FEE = 257e3  # 0.257 XTZ
+RA_BURN_FEE = 257000  # 0.257 XTZ
 RA_STORAGE = 300
 
 class BatchPayer():

--- a/src/pay/payment_consumer.py
+++ b/src/pay/payment_consumer.py
@@ -8,6 +8,7 @@ from Constants import EXIT_PAYMENT_TYPE, PaymentStatus
 from NetworkConfiguration import is_mainnet
 from calc.calculate_phase5 import CalculatePhase5
 from calc.calculate_phase6 import CalculatePhase6
+from calc.calculate_phase7 import CalculatePhase7
 from emails.email_manager import EmailManager
 from log_config import main_logger
 from model.reward_log import cmp_by_type_balance, TYPE_MERGED, TYPE_FOUNDER, TYPE_OWNER, TYPE_DELEGATOR
@@ -33,7 +34,8 @@ def count_and_log_failed(payment_logs):
 
 class PaymentConsumer(threading.Thread):
     def __init__(self, name, payments_dir, key_name, client_path, payments_queue, node_addr, wllt_clnt_mngr,
-                 network_config, args=None, verbose=None, dry_run=None, delegator_pays_xfer_fee=True, dest_map=None,
+                 network_config, args=None, verbose=None, dry_run=None, reactivate_zeroed=True,
+                 delegator_pays_ra_fee=True, delegator_pays_xfer_fee=True, dest_map=None,
                  publish_stats=True):
         super(PaymentConsumer, self).__init__()
 
@@ -48,7 +50,9 @@ class PaymentConsumer(threading.Thread):
         self.dry_run = dry_run
         self.mm = EmailManager()
         self.wllt_clnt_mngr = wllt_clnt_mngr
+        self.reactivate_zeroed = reactivate_zeroed
         self.delegator_pays_xfer_fee = delegator_pays_xfer_fee
+        self.delegator_pays_ra_fee = delegator_pays_ra_fee
         self.publish_stats = publish_stats
         self.args = args
         self.network_config = network_config
@@ -60,7 +64,7 @@ class PaymentConsumer(threading.Thread):
     def run(self):
         while True:
             try:
-                # 1-  wait until a reward is present
+                # 1 - wait until a reward is present
                 payment_batch = self.payments_queue.get(True)
 
                 payment_items = payment_batch.batch
@@ -79,19 +83,26 @@ class PaymentConsumer(threading.Thread):
 
                 logger.info("Starting payments for cycle {}".format(pymnt_cycle))
 
+                # Handle remapping of payment to alternate address
                 phase5 = CalculatePhase5(self.dest_map)
                 payment_items, _ = phase5.calculate(payment_items, None)
 
+                # Merge payments to same address
                 phase6 = CalculatePhase6(addr_dest_dict=self.dest_map)
                 payment_items, _ = phase6.calculate(payment_items, None)
 
-                # filter out non-payable items
+                # Filter zero-balance addresses based on config
+                phase7 = CalculatePhase7(self.reactivate_zeroed)
+                payment_items = phase7.calculate(payment_items)
+
+                # Filter out non-payable items
                 payment_items = [pi for pi in payment_items if pi.payable]
 
                 payment_items.sort(key=functools.cmp_to_key(cmp_by_type_balance))
 
                 batch_payer = BatchPayer(self.node_addr, self.key_name, self.wllt_clnt_mngr,
-                                         self.delegator_pays_xfer_fee, self.network_config)
+                                         self.delegator_pays_ra_fee, self.delegator_pays_xfer_fee,
+                                         self.network_config)
 
                 # 3- do the payment
                 payment_logs, total_attempts = batch_payer.pay(payment_items, self.verbose, dry_run=self.dry_run)

--- a/src/pay/payment_producer.py
+++ b/src/pay/payment_producer.py
@@ -223,8 +223,10 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
                 reward_model = self.reward_api.get_rewards_for_cycle_map(pymnt_cycle, expected_reward)
             else:
                 reward_model = self.reward_api.get_rewards_for_cycle_map(pymnt_cycle)
+
             # 2- calculate rewards
             reward_logs, total_amount = self.payment_calc.calculate(reward_model)
+
             # set cycle info
             for rl in reward_logs: rl.cycle = pymnt_cycle
             total_amount_to_pay = sum([rl.amount for rl in reward_logs if rl.payable])
@@ -235,6 +237,7 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
 
                 # 5- send to payment consumer
                 self.payments_queue.put(PaymentBatch(self, pymnt_cycle, reward_logs))
+
                 # logger.info("Total payment amount is {:,} mutez. %s".format(total_amount_to_pay),
                 #            "" if self.delegator_pays_xfer_fee else "(Transfer fee is not included)")
 
@@ -244,10 +247,9 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
 
                 # 6- create calculations report file. This file contains calculations details
                 self.create_calculations_report(reward_logs, report_file_path, total_amount)
-                # 7- next cycle
-                # processing of cycle is done
-                logger.info(
-                    "Reward creation is done for cycle {}, created {} rewards.".format(pymnt_cycle, len(reward_logs)))
+
+                # 7- processing of cycle is done
+                logger.info("Reward creation is done for cycle {}, created {} rewards.".format(pymnt_cycle, len(reward_logs)))
 
             elif total_amount_to_pay == 0:
                 logger.info("Total payment amount is 0. Nothing to pay!")
@@ -285,10 +287,11 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
             writer = csv.writer(f, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
             # write headers and total rewards
             writer.writerow(
-                ["address", "type", "balance", "ratio", "fee_ratio", "amount", "fee_amount", "fee_rate", "payable",
+                ["address", "type", "staked_balance", "current_balance", "ratio", "fee_ratio", "amount", "fee_amount", "fee_rate", "payable",
                  "skipped", "atphase", "desc", "payment_address"])
 
-            writer.writerow([self.baking_address, "B", sum([pl.balance for pl in payment_logs]),
+            writer.writerow([self.baking_address, "B", sum([pl.staking_balance for pl in payment_logs]),
+                             "{0:f}".format(1.0),
                              "{0:f}".format(1.0),
                              "{0:f}".format(0.0),
                              "{0:f}".format(total_rewards),
@@ -300,7 +303,7 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
 
             for pymnt_log in payment_logs:
                 # write row to csv file
-                array = [pymnt_log.address, pymnt_log.type, pymnt_log.balance,
+                array = [pymnt_log.address, pymnt_log.type, pymnt_log.staking_balance, pymnt_log.current_balance,
                          "{0:.10f}".format(pymnt_log.ratio),
                          "{0:.10f}".format(pymnt_log.service_fee_ratio),
                          "{0:f}".format(pymnt_log.amount),
@@ -312,12 +315,15 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
                          pymnt_log.paymentaddress]
                 writer.writerow(array)
 
-                logger.debug("Reward created for address %s type %s balance {:>10.2f} ratio {:.6f} fee_ratio {:.6f} "
-                             "amount {:>10.6f} fee_amount {:>4.6f} fee_rate {:.2f} payable %s skipped %s atphase %s desc %s pay_addr %s"
-                             .format(pymnt_log.balance / MUTEZ, pymnt_log.ratio, pymnt_log.service_fee_ratio,
+                logger.debug("Reward created for %s type: %s, stake bal: {:>10.2f}, cur bal: {:>10.2f}, ratio: {:.6f}, fee_ratio: {:.6f}, "
+                             "amount: {:>10.6f}, fee_amount: {:>4.6f}, fee_rate: {:.2f}, payable: %s, skipped: %s, at-phase: %s, "
+                             "desc: %s, pay_addr: %s"
+                             .format(pymnt_log.staking_balance / MUTEZ, pymnt_log.current_balance / MUTEZ,
+                                     pymnt_log.ratio, pymnt_log.service_fee_ratio,
                                      pymnt_log.amount / MUTEZ, pymnt_log.service_fee_amount / MUTEZ,
                                      pymnt_log.service_fee_rate), pymnt_log.address, pymnt_log.type, pymnt_log.payable,
                                      pymnt_log.skipped, pymnt_log.skippedatphase, pymnt_log.desc, pymnt_log.paymentaddress)
+
         logger.info("Calculation report is created at '{}'".format(report_file_path))
 
     @staticmethod

--- a/src/pay_for.py
+++ b/src/pay_for.py
@@ -122,7 +122,7 @@ def main(args):
                             key_name=args.paymentaddress,
                             client_path=client_path, payments_queue=payments_queue, node_addr=args.node_addr,
                             wllt_clnt_mngr=wllt_clnt_mngr, verbose=args.verbose, dry_run=dry_run,
-                            delegator_pays_xfer_fee=False)
+                            reactivate_zeroed=False, delegator_pays_ra_fee=False, delegator_pays_xfer_fee=False)
         time.sleep(1)
         c.start()
 

--- a/src/rpc/rpc_reward_api.py
+++ b/src/rpc/rpc_reward_api.py
@@ -8,14 +8,13 @@ from model.reward_provider_model import RewardProviderModel
 
 logger = main_logger
 
+COMM_HEAD = "{}/chains/main/blocks/head"
+COMM_DELEGATES = "{}/chains/main/blocks/{}/context/delegates/{}"
+COMM_BLOCK = "{}/chains/main/blocks/{}"
+COMM_SNAPSHOT = COMM_BLOCK + "/context/raw/json/cycle/{}/roll_snapshot"
+COMM_DELEGATE_BALANCE = "{}/chains/main/blocks/{}/context/contracts/{}/balance"
 
 class RpcRewardApiImpl(RewardApi):
-    COMM_HEAD = "{}/chains/main/blocks/head"
-    COMM_DELEGATES = "{}/chains/main/blocks/{}/context/delegates/{}"
-    COMM_BLOCK = "{}/chains/main/blocks/{}"
-    COMM_SNAPSHOT = COMM_BLOCK + "/context/raw/json/cycle/{}/roll_snapshot"
-    COMM_DELEGATE_BALANCE = "{}/chains/main/blocks/{}/context/contracts/{}"
-
     def __init__(self, nw, baking_address, node_url, verbose=True):
         super(RpcRewardApiImpl, self).__init__()
 
@@ -30,24 +29,13 @@ class RpcRewardApiImpl(RewardApi):
 
         self.verbose = verbose
 
-        # replace protocol placeholder
-        self.COMM_HEAD = self.COMM_HEAD
-        self.COMM_DELEGATES = self.COMM_DELEGATES
-        self.COMM_BLOCK = self.COMM_BLOCK
-        self.COMM_SNAPSHOT = self.COMM_SNAPSHOT
-        self.COMM_DELEGATE_BALANCE = self.COMM_DELEGATE_BALANCE
-
-    def get_nb_delegators(self, cycle, current_level):
-        _, delegators = self.__get_delegators_and_delgators_balance(cycle, current_level)
-        return len(delegators)
-
     def get_rewards_for_cycle_map(self, cycle):
         current_level, current_cycle = self.__get_current_level()
         logger.debug("Current level {}, current cycle {}".format(current_level, current_cycle))
 
         reward_data = {}
         reward_data["delegate_staking_balance"], reward_data[
-            "delegators"] = self.__get_delegators_and_delgators_balance(cycle, current_level)
+            "delegators"] = self.__get_delegators_and_delgators_balances(cycle, current_level)
         reward_data["delegators_nb"] = len(reward_data["delegators"])
 
         # Get last block in cycle where rewards are unfrozen
@@ -69,14 +57,14 @@ class RpcRewardApiImpl(RewardApi):
         reward_model = RewardProviderModel(reward_data["delegate_staking_balance"], reward_data["total_rewards"],
                                            reward_data["delegators"])
 
-        logger.debug("delegate_staking_balance={}, total_rewards = {}".format(reward_data["delegate_staking_balance"],
+        logger.debug("delegate_staking_balance = {}, total_rewards = {}".format(reward_data["delegate_staking_balance"],
                                                                               reward_data["total_rewards"]))
         logger.debug("delegators = {}".format(reward_data["delegators"]))
 
         return reward_model
 
     def __get_unfrozen_rewards(self, level_of_last_block_in_unfreeze_cycle, cycle):
-        request_metadata = self.COMM_BLOCK.format(self.node_url, level_of_last_block_in_unfreeze_cycle) + '/metadata'
+        request_metadata = COMM_BLOCK.format(self.node_url, level_of_last_block_in_unfreeze_cycle) + '/metadata'
         metadata = self.do_rpc_request(request_metadata)
         balance_updates = metadata["balance_updates"]
         unfrozen_rewards = unfrozen_fees = 0
@@ -120,50 +108,84 @@ class RpcRewardApiImpl(RewardApi):
         return response
 
     def __get_current_level(self):
-        head = self.do_rpc_request(self.COMM_HEAD.format(self.node_url))
+        head = self.do_rpc_request(COMM_HEAD.format(self.node_url))
         current_level = int(head["metadata"]["level"]["level"])
         current_cycle = int(head["metadata"]["level"]["cycle"])
         # head_hash = head["hash"]
 
         return current_level, current_cycle
+    
+    def __get_delegators_and_delgators_balances(self, cycle, current_level):
 
-    def __get_delegators_and_delgators_balance(self, cycle, current_level):
-
+        # calculate the hash of the block for the chosen snapshot of the rewards cycle
         hash_snapshot_block = self.__get_snapshot_block_hash(cycle, current_level)
         if hash_snapshot_block == "":
             return 0, []
 
-        request = self.COMM_DELEGATES.format(self.node_url, hash_snapshot_block, self.baking_address)
+        # construct RPC for getting list of delegates
+        get_delegates_request = COMM_DELEGATES.format(self.node_url, hash_snapshot_block, self.baking_address)
 
         delegate_staking_balance = 0
         delegators = {}
 
         try:
-            response = self.do_rpc_request(request)
+            # get RPC response for delegates and staking balance
+            response = self.do_rpc_request(get_delegates_request)
             delegate_staking_balance = int(response["staking_balance"])
 
+            # loop over delegates; get snapshot balance, and current balance
             delegators_addresses = response["delegated_contracts"]
+            d_a_len = len(delegators_addresses)
+            
+            if d_a_len == 0:
+                raise RpcRewardApiError("No delegators found")
+            
+            # Loop over delegators, get balances
             for idx, delegator in enumerate(delegators_addresses):
-                request = self.COMM_DELEGATE_BALANCE.format(self.node_url, hash_snapshot_block, delegator)
-                response = self.do_rpc_request(request)
 
-                sleep(0.5)  # be nice to public node service
+                # create new dictionary for each delegator
+                d_info = {"staking_balance": 0, "current_balance": 0}
 
-                response = None
+                get_staking_balance_request = COMM_DELEGATE_BALANCE.format(self.node_url, hash_snapshot_block, delegator)
+                get_current_balance_request = COMM_DELEGATE_BALANCE.format(self.node_url, "head", delegator)
 
-                while not response:
+                staking_balance_response = None
+                current_balance_response = None
+
+                while not staking_balance_response:
                     try:
-                        response = self.do_rpc_request(request, time_out=5)
+                        staking_balance_response = self.do_rpc_request(get_staking_balance_request, time_out=5)
                     except:
-                        logger.debug("Fetching delegator info failed {}, will retry", delegator)
+                        logger.debug("Fetching delegator staking balance failed {}, will retry", delegator)
 
-                delegators[delegator] = int(response["balance"])
+                d_info["staking_balance"] = int(staking_balance_response)
+
+                sleep(0.4) # Be nice to public RPC since we are now making 2x the amount of RPC calls
+
+                while not current_balance_response:
+                    try:
+                        current_balance_response = self.do_rpc_request(get_current_balance_request, time_out=5)
+                    except:
+                        logger.debug("Fetching delegator current balance failed {}, will retry", delegator)
+
+                d_info["current_balance"] = int(current_balance_response)
 
                 logger.debug(
-                    "Delegator info ({}/{}) fetched: address {}, balance {}".format(idx, len(delegators_addresses),
-                                                                                    delegator, delegators[delegator]))
-        except:
-            logger.warn('No delegators or unexpected error', exc_info=True)
+                    "Delegator info ({}/{}) fetched: address {}, staked balance {}, current balance {} ".format(
+                        idx+1, d_a_len, delegator, d_info["staking_balance"], d_info["current_balance"]))
+
+                # "append" to master dict
+                delegators[delegator] = d_info
+
+            # Sanity check. We should have fetched info for all delegates. If we didn't, something went wrong
+            d_len = len(delegators)
+            if d_a_len != d_len:
+                raise RpcRewardApiError("Did not collect info for all delegators, {}/{}".format(d_a_len, d_len))
+
+        except RpcRewardApiError as r:
+            logger.warn("RPC API Error: {}".format(r), exc_info=True)
+        except Exception as e:
+            logger.warn("Unexpected error: {}".format(e), exc_info=True)
 
         return delegate_staking_balance, delegators
 
@@ -175,7 +197,7 @@ class RpcRewardApiImpl(RewardApi):
         block_level = cycle * self.blocks_per_cycle + 1
 
         if current_level - snapshot_level >= 0:
-            request = self.COMM_SNAPSHOT.format(self.node_url, block_level, cycle)
+            request = COMM_SNAPSHOT.format(self.node_url, block_level, cycle)
             chosen_snapshot = self.do_rpc_request(request)
 
             level_snapshot_block = (cycle - self.preserved_cycles - 2) * self.blocks_per_cycle + (
@@ -185,3 +207,6 @@ class RpcRewardApiImpl(RewardApi):
         else:
             logger.info("Cycle too far in the future")
             return ""
+
+class RpcRewardApiError(Exception):
+    pass

--- a/src/tzstats/tzstats_api_constants.py
+++ b/src/tzstats/tzstats_api_constants.py
@@ -1,4 +1,4 @@
-# Income
+# Income/Rewards Breakdown
 idx_income_expected_income = 19
 idx_income_total_income = 21
 idx_income_total_bonds = 22
@@ -20,9 +20,12 @@ idx_income_lost_accusation_deposits = 35
 idx_income_lost_revelation_fees = 36
 idx_income_lost_revelation_rewards = 37
 
-#snapshot
-idx_baker_balance = 11
-idx_baker_delegated = 12
+# Cycle Snapshot
+idx_balance = 0
+idx_baker_delegated = 1
+idx_delegator_address = 2
 
-idx_delegator_balance = 11
-idx_delegator_address = 15
+# Current balances
+idx_cb_delegator_id = 0
+idx_cb_current_balance = 1
+idx_cb_delegator_address = 2

--- a/src/tzstats/tzstats_reward_api.py
+++ b/src/tzstats/tzstats_reward_api.py
@@ -22,9 +22,7 @@ class TzStatsRewardApiImpl(RewardApi):
         root = self.helper.get_rewards_for_cycle(cycle, expected_reward, self.verbose)
 
         delegate_staking_balance = root["delegate_staking_balance"]
-
         total_reward_amount = root["total_reward_amount"]
+        delegators_balances_dict = root["delegators_balances"]
 
-        delegators_balance = root["delegators_balance"]
-
-        return RewardProviderModel(delegate_staking_balance, total_reward_amount, delegators_balance)
+        return RewardProviderModel(delegate_staking_balance, total_reward_amount, delegators_balances_dict)

--- a/src/tzstats/tzstats_reward_provider_helper.py
+++ b/src/tzstats/tzstats_reward_provider_helper.py
@@ -39,6 +39,8 @@ class TzStatsRewardProviderHelper:
         #
         uri = self.api['API_URL'] + rewards_split_call.format(self.baking_address, cycle)
 
+        sleep(0.5) # be nice to tzstats
+
         if verbose:
             logger.debug("Requesting rewards breakdown, {}".format(uri))
 
@@ -69,6 +71,8 @@ class TzStatsRewardProviderHelper:
         #
         uri = self.api['API_URL'] + delegators_call.format(cycle - self.preserved_cycles - 2, self.baking_address)
 
+        sleep(0.5) # be nice to tzstats
+
         if verbose:
             logger.debug("Requesting staking balances of delegators, {}".format(uri))
 
@@ -95,7 +99,7 @@ class TzStatsRewardProviderHelper:
         #
         # Get current balance of delegates
         #
-        # This is done in 2 phases. 1) make a single API call to tzscan, retrieving an array
+        # This is done in 2 phases. 1) make a single API call to tzstats, retrieving an array
         # of arrays with current balance of each delegator who "currently" delegates to delegate. There may
         # be a case where the delegator has changed delegations and would therefor not be in this array.
         # Thus, 2) determines which delegators are not in the first result, and makes individual
@@ -105,6 +109,8 @@ class TzStatsRewardProviderHelper:
         # Phase 1
         #
         uri = self.api['API_URL'] + batch_current_balance_call.format(self.baking_address)
+
+        sleep(0.5) # be nice to tzstats
 
         if verbose:
             logger.debug("Requesting current balance of delegators, phase 1, {}".format(uri))
@@ -146,8 +152,10 @@ class TzStatsRewardProviderHelper:
         if len(need_curr_balance_fetch) > 0:
 
             for d in need_curr_balance_fetch:
-            
+
                 uri = self.api['API_URL'] + single_current_balance_call.format(d)
+
+                sleep(0.5) # be nice to tzstats
                 
                 if verbose:
                     logger.debug("Requesting current balance of delegator, phase 2, {}".format(uri))

--- a/src/tzstats/tzstats_reward_provider_helper.py
+++ b/src/tzstats/tzstats_reward_provider_helper.py
@@ -30,6 +30,8 @@ class TzStatsRewardProviderHelper:
 
     def get_rewards_for_cycle(self, cycle, expected_reward = False, verbose=False):
         #############
+        ## TODO: Fetch current balance to check if zeroed
+
         root = {"delegate_staking_balance": 0, "total_reward_amount": 0, "delegators_balance": {}}
 
         uri = self.api['API_URL'] + rewards_split_call.format(self.baking_address, cycle)

--- a/src/tzstats/tzstats_reward_provider_helper.py
+++ b/src/tzstats/tzstats_reward_provider_helper.py
@@ -7,7 +7,9 @@ from tzstats.tzstats_api_constants import *
 logger = main_logger
 
 rewards_split_call = '/tables/income?address={}&cycle={}'
-delegators_call = '/tables/snapshot?cycle={}&is_selected=1&delegate={}&limit=50000'
+delegators_call = '/tables/snapshot?cycle={}&is_selected=1&delegate={}&columns=balance,delegated,address&limit=50000'
+batch_current_balance_call = '/tables/account?delegate={}&columns=row_id,spendable_balance,address'
+single_current_balance_call = '/tables/account?address={}&columns=row_id,spendable_balance,address'
 
 PREFIX_API = {'MAINNET': {'API_URL': 'http://api.tzstats.com'},
               'ZERONET': {'API_URL': 'http://api.zeronet.tzstats.com'},
@@ -29,20 +31,21 @@ class TzStatsRewardProviderHelper:
         self.baking_address = baking_address
 
     def get_rewards_for_cycle(self, cycle, expected_reward = False, verbose=False):
-        #############
-        ## TODO: Fetch current balance to check if zeroed
+    
+        root = {"delegate_staking_balance": 0, "total_reward_amount": 0, "delegators_balances": {}}
 
-        root = {"delegate_staking_balance": 0, "total_reward_amount": 0, "delegators_balance": {}}
-
+        #
+        # Get rewards breakdown for cycle
+        #
         uri = self.api['API_URL'] + rewards_split_call.format(self.baking_address, cycle)
 
         if verbose:
-            logger.debug("Requesting {}".format(uri))
+            logger.debug("Requesting rewards breakdown, {}".format(uri))
 
         resp = requests.get(uri, timeout=5)
 
         if verbose:
-            logger.debug("Response from tzstats is {}".format(resp))
+            logger.debug("Response from tzstats is {}".format(resp.content.decode("utf8")))
 
         if resp.status_code != 200:
             # This means something went wrong.
@@ -52,18 +55,27 @@ class TzStatsRewardProviderHelper:
         if expected_reward:
             root["total_reward_amount"] = int(1e6 * float(resp[idx_income_expected_income]))
         else:
-            root["total_reward_amount"] = int(1e6 * (float(resp[idx_income_baking_income]) + float(resp[idx_income_endorsing_income]) + float(resp[idx_income_seed_income]) +  float(resp[idx_income_fees_income])  -  float(resp[idx_income_lost_accusation_fees]) -  float(resp[idx_income_lost_accusation_rewards]) -  float(resp[idx_income_lost_revelation_fees]) -  float(resp[idx_income_lost_revelation_rewards])))
+            root["total_reward_amount"] = int(1e6 * (float(resp[idx_income_baking_income]) 
+            + float(resp[idx_income_endorsing_income]) 
+            + float(resp[idx_income_seed_income]) 
+            + float(resp[idx_income_fees_income]) 
+            - float(resp[idx_income_lost_accusation_fees]) 
+            - float(resp[idx_income_lost_accusation_rewards]) 
+            - float(resp[idx_income_lost_revelation_fees]) 
+            - float(resp[idx_income_lost_revelation_rewards])))
 
-
+        #
+        # Get staking balances of delegators at snapshot block
+        #
         uri = self.api['API_URL'] + delegators_call.format(cycle - self.preserved_cycles - 2, self.baking_address)
 
         if verbose:
-            logger.debug("Requesting {}".format(uri))
+            logger.debug("Requesting staking balances of delegators, {}".format(uri))
 
         resp = requests.get(uri, timeout=5)
 
         if verbose:
-            logger.debug("Response from tzstats is {}".format(resp))
+            logger.debug("Response from tzstats is {}".format(resp.content.decode("utf8")))
 
         if resp.status_code != 200:
             # This means something went wrong.
@@ -72,9 +84,93 @@ class TzStatsRewardProviderHelper:
         resp = resp.json()
 
         for delegator in resp:
+
             if delegator[idx_delegator_address] == self.baking_address:
-                root["delegate_staking_balance"] = int(1e6 * (float(delegator[idx_baker_balance]) + float(delegator[idx_baker_delegated])))
+                root["delegate_staking_balance"] = int(1e6 * (float(delegator[idx_balance]) + float(delegator[idx_baker_delegated])))
             else:
-                root["delegators_balance"][delegator[idx_delegator_address]] = int(1e6 * float(delegator[idx_delegator_balance]))
+                delegator_info = {"staking_balance": 0, "current_balance": 0}
+                delegator_info["staking_balance"] = int(1e6 * float(delegator[idx_balance]))
+                root["delegators_balances"][delegator[idx_delegator_address]] = delegator_info
+
+        #
+        # Get current balance of delegates
+        #
+        # This is done in 2 phases. 1) make a single API call to tzscan, retrieving an array
+        # of arrays with current balance of each delegator who "currently" delegates to delegate. There may
+        # be a case where the delegator has changed delegations and would therefor not be in this array.
+        # Thus, 2) determines which delegators are not in the first result, and makes individual
+        # calls to get their balance. This approach should reduce the overall number of API calls made to tzstats.
+        #
+
+        # Phase 1
+        #
+        uri = self.api['API_URL'] + batch_current_balance_call.format(self.baking_address)
+
+        if verbose:
+            logger.debug("Requesting current balance of delegators, phase 1, {}".format(uri))
+
+        resp = requests.get(uri, timeout=5)
+
+        if verbose:
+            logger.debug("Response from tzstats is {}".format(resp.content.decode("utf8")))
+
+        if resp.status_code != 200:
+            # This means something went wrong.
+            raise ApiProviderException('GET {} {}'.format(uri, resp.status_code))
+
+        resp = resp.json()
+
+        # Will use these two lists to determine who has/has not been fetched
+        staked_bal_delegators = root["delegators_balances"].keys()
+        curr_bal_delegators = []
+        
+        for delegator in resp:
+            delegator_addr = delegator[idx_cb_delegator_address]
+            
+            # If delegator is in this batch, but has no staking balance for this reward cycle,
+            # then they must be a new delegator and are not receiving rewards at this time.
+            # We can ignore them.
+            if delegator_addr not in staked_bal_delegators:
+                continue
+
+            root["delegators_balances"][delegator_addr]["current_balance"] = int(1e6 * float(delegator[idx_cb_current_balance]))
+            curr_bal_delegators.append(delegator_addr)
+
+        # Phase 2
+        #
+        
+        # Who was not in this result?
+        need_curr_balance_fetch = list(set(staked_bal_delegators) - set(curr_bal_delegators))
+
+        # Fetch individual not in original batch
+        if len(need_curr_balance_fetch) > 0:
+
+            for d in need_curr_balance_fetch:
+            
+                uri = self.api['API_URL'] + single_current_balance_call.format(d)
+                
+                if verbose:
+                    logger.debug("Requesting current balance of delegator, phase 2, {}".format(uri))
+                
+                resp = requests.get(uri, timeout=5)
+                
+                if verbose:
+                    logger.debug("Response from tzstats is {}".format(resp.content.decode("utf8")))
+
+                if resp.status_code != 200:
+                    # This means something went wrong.
+                    raise ApiProviderException('GET {} {}'.format(uri, resp.status_code))
+                
+                resp = resp.json()[0]
+                root["delegators_balances"][d]["current_balance"] = int(1e6 * float(resp[idx_cb_current_balance]))
+                curr_bal_delegators.append(d)
+        
+        # All done fetching balances.
+        # Sanity check.
+        n_curr_balance = len(curr_bal_delegators)
+        n_stake_balance = len(staked_bal_delegators)
+        
+        if n_curr_balance != n_stake_balance:
+            raise ApiProviderException('Did not fetch all balances {}/{}'.format(n_curr_balance, n_stake_balance))
 
         return root

--- a/src/tzstats/tzstats_reward_provider_helper.py
+++ b/src/tzstats/tzstats_reward_provider_helper.py
@@ -1,5 +1,6 @@
 import requests
 
+from time import sleep
 from exception.api_provider import ApiProviderException
 from log_config import main_logger
 from tzstats.tzstats_api_constants import *


### PR DESCRIPTION
When an address is zeroed out (0 xtz), the address will be "garbage collected" by the chain some number of cycles later. In order to reactivate this address, so that it can receive rewards payment, the sender must pay a burn fee of 0.257 XTZ and some additional storage cost.

Attempting to pay a zeroed address within a bulk operation will fail the entire operation and the sender will have lost all transfer fees from each failed transaction within the operation.

Whether or not this burn fee should be the bakers' responsibility to pay, is up to the individual baker, and the option is supported in this PR.

This PR adds 2 new configuration parameters:
* reactivate_zeroed: True/False - If True, an account to be paid found with a 0 balance will be reactivated, incurring the necessary burn fee and storage, and rewards will be sent. If False, any account with a 0 balance will be skipped payment. This will be noted in the CSV report.
* delegator_pays_ra_fee: True/False - Functions just like delegator_pays_xfer_fee, except refers to the burn/reactivation fee. If True, the burn fee is subtracted from the reward payment (ie: delegate pays). If False, burn fee is paid for by baker.

New questions in configure.py:
```
If a destination address has 0 balance, should burn fee be paid to reactivate? 1 for Yes, 0 for No. Type enter for Yes >
0
Who is going to pay for 0XTZ-balance reactivation/burn fee: 0 for delegator, 1 for delegate. Type enter for delegator >
1
```

Personal note: This pr took a lot of free time to develop and test. If it helps you, please consider a donation, tz1Sr7G7aSDE5REnvAYB5kR4iLRRVgkEypH9 Thanks