### PR TITLE
Exit on failure to parse missing config parameters 

### DIFF
--- a/src/config/test_BakingYamlConfParser.py
+++ b/src/config/test_BakingYamlConfParser.py
@@ -17,7 +17,9 @@ class TestYamlAppConfParser(TestCase):
         payment_address : tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj
         founders_map : {'KT2Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj':0.5,'KT3Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj':0.5}
         owners_map : {'KT2Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj':0.5,'KT3Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj':0.5}
-        service_fee : 4.53  
+        service_fee : 4.53
+        reactivate_zeroed: False
+        delegator_pays_ra_fee: True
         """
 
         managers = {'tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj': 'tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj',
@@ -43,10 +45,15 @@ class TestYamlAppConfParser(TestCase):
 
         self.assertEqual(cnf_prsr.get_conf_obj_attr('baking_address'), 'tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj')
         self.assertEqual(cnf_prsr.get_conf_obj_attr('payment_address'), 'tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj')
+
         self.assertEqual(cnf_prsr.get_conf_obj_attr('__payment_address_pkh'), 'tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj')
         self.assertEqual(cnf_prsr.get_conf_obj_attr('__payment_address_manager'), 'tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj')
         self.assertEqual(cnf_prsr.get_conf_obj_attr('__payment_address_type'), AddrType.TZ)
-        self.assertEqual(0, cnf_prsr.get_conf_obj_attr('min_delegation_amt'))
+
+        self.assertEqual(cnf_prsr.get_conf_obj_attr('min_delegation_amt'), 0)
+
+        self.assertEqual(cnf_prsr.get_conf_obj_attr('reactivate_zeroed'), False)
+        self.assertEqual(cnf_prsr.get_conf_obj_attr('delegator_pays_ra_fee'), True)
 
     def test_validate_no_founders_map(self):
         data_no_founders = """
@@ -54,7 +61,9 @@ class TestYamlAppConfParser(TestCase):
         baking_address : tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj
         payment_address : tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj
         owners_map : {'KT2Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj':0.5,'KT3Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj':0.5}
-        service_fee : 4.5  
+        service_fee : 4.5
+        reactivate_zeroed: False
+        delegator_pays_ra_fee: True
         """
 
         managers_map = {'tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj': 'tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj'}
@@ -81,10 +90,15 @@ class TestYamlAppConfParser(TestCase):
         self.assertEqual(cnf_prsr.get_conf_obj_attr('__payment_address_pkh'), 'tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj')
         self.assertEqual(cnf_prsr.get_conf_obj_attr('__payment_address_manager'), 'tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj')
         self.assertEqual(cnf_prsr.get_conf_obj_attr('__payment_address_type'), AddrType.TZ)
+
         self.assertEqual(cnf_prsr.get_conf_obj_attr('founders_map'), dict())
         self.assertEqual(cnf_prsr.get_conf_obj_attr('specials_map'), dict())
         self.assertEqual(cnf_prsr.get_conf_obj_attr('supporters_set'), set())
-        self.assertEqual(0, cnf_prsr.get_conf_obj_attr('min_delegation_amt'))
+
+        self.assertEqual(cnf_prsr.get_conf_obj_attr('min_delegation_amt'), 0)
+
+        self.assertEqual(cnf_prsr.get_conf_obj_attr('reactivate_zeroed'), False)
+        self.assertEqual(cnf_prsr.get_conf_obj_attr('delegator_pays_ra_fee'), True)
 
     def test_validate_pymnt_alias(self):
         data_no_founders = """
@@ -92,8 +106,10 @@ class TestYamlAppConfParser(TestCase):
         baking_address : tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj
         payment_address : tzPay
         owners_map : {'KT2Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj':0.5,'KT3Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj':0.5}
-        service_fee : 4.5  
+        service_fee : 4.5
         min_delegation_amt : 100
+        reactivate_zeroed: False
+        delegator_pays_ra_fee: True
         """
 
         managers_map = {'tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj': 'tz1Z1tMai15JWUWeN2PKL9faXXVPMuWamzJj',
@@ -127,6 +143,7 @@ class TestYamlAppConfParser(TestCase):
         self.assertEqual(cnf_prsr.get_conf_obj_attr('specials_map'), dict())
         self.assertEqual(cnf_prsr.get_conf_obj_attr('supporters_set'), set())
 
-        self.assertEqual(100, cnf_prsr.get_conf_obj_attr('min_delegation_amt'))
+        self.assertEqual(cnf_prsr.get_conf_obj_attr('min_delegation_amt'), 100)
 
-
+        self.assertEqual(cnf_prsr.get_conf_obj_attr('reactivate_zeroed'), False)
+        self.assertEqual(cnf_prsr.get_conf_obj_attr('delegator_pays_ra_fee'), True)

--- a/src/config/yaml_baking_conf_parser.py
+++ b/src/config/yaml_baking_conf_parser.py
@@ -3,7 +3,8 @@ from config.yaml_conf_parser import YamlConfParser
 from exception.configuration import ConfigurationException
 from model.baking_conf import FOUNDERS_MAP, OWNERS_MAP, BAKING_ADDRESS, SUPPORTERS_SET, SERVICE_FEE, \
     FULL_SUPPORTERS_SET, MIN_DELEGATION_AMT, PAYMENT_ADDRESS, SPECIALS_MAP, \
-    DELEGATOR_PAYS_XFER_FEE, RULES_MAP, MIN_DELEGATION_KEY, TOF, TOB, TOE, EXCLUDED_DELEGATORS_SET_TOB, \
+    DELEGATOR_PAYS_XFER_FEE, REACTIVATE_ZEROED, DELEGATOR_PAYS_RA_FEE, \
+    RULES_MAP, MIN_DELEGATION_KEY, TOF, TOB, TOE, EXCLUDED_DELEGATORS_SET_TOB, \
     EXCLUDED_DELEGATORS_SET_TOE, EXCLUDED_DELEGATORS_SET_TOF, DEST_MAP
 from util.address_validator import AddressValidator
 from util.fee_validator import FeeValidator
@@ -37,6 +38,9 @@ class BakingYamlConfParser(YamlConfParser):
         self.validate_specials_map(conf_obj)
         self.validate_dest_map(conf_obj)
         self.parse_bool(conf_obj, DELEGATOR_PAYS_XFER_FEE, True)
+        self.parse_bool(conf_obj, REACTIVATE_ZEROED, None)
+        self.parse_bool(conf_obj, DELEGATOR_PAYS_RA_FEE, None)
+        
 
     def set(self, key, value):
         self.conf_obj[key] = value
@@ -248,8 +252,13 @@ class BakingYamlConfParser(YamlConfParser):
     def parse_bool(self, conf_obj, param_name, default):
 
         if param_name not in conf_obj:
-            conf_obj[param_name] = default
-            return
+        
+            # If required param (ie: no default), raise exception if not defined
+            if default is None:
+                raise ConfigurationException("Parameter '{}' is not present in config file. Please consult the documentation and add this parameter.".format(param_name))
+            else:
+                conf_obj[param_name] = default
+                return
 
         # already a bool value
         if type(conf_obj[param_name]) == type(False):


### PR DESCRIPTION
- Treat new parameters as having no default, forcing users to pick their own setting