### PR TITLE
Change example reactivation to True

### DIFF
--- a/examples/tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889.yaml
+++ b/examples/tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889.yaml
@@ -7,7 +7,7 @@ owners_map : {tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889: 0.3, KT1KLQbYFtFZ5mAEnfEMZaW
 specials_map : {KT19g4JHTd3QYuYcpKFFiwViEzQ5n6ovYx1V: 7.5}
 supporters_set : {KT1SenDhs9rL9fpZV3cLRXFovEBafmGqkki8}
 min_delegation_amt : 1000
-reactivate_zeroed : False
+reactivate_zeroed : True
 delegator_pays_xfer_fee : True
 delegator_pays_ra_fee : True
 rules_map:


### PR DESCRIPTION
Admins at BakingBad have requested we make this example show True as there really isn't a good reason for a baker to not reactivate an account if their reward is greater than burnFee+txnFee.

The configuration.py script already has this default as True, so only this example needs changing.